### PR TITLE
feature/be/#29-feature-api-reponse 객체

### DIFF
--- a/daycan-back/api/src/main/java/com/daycan/common/logging/AopConfig.java
+++ b/daycan-back/api/src/main/java/com/daycan/common/logging/AopConfig.java
@@ -1,4 +1,4 @@
-package com.daycan.logging;
+package com.daycan.common.logging;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;

--- a/daycan-back/api/src/main/java/com/daycan/common/logging/AopLogger.java
+++ b/daycan-back/api/src/main/java/com/daycan/common/logging/AopLogger.java
@@ -1,4 +1,4 @@
-package com.daycan.logging;
+package com.daycan.common.logging;
 
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/daycan-back/api/src/main/java/com/daycan/common/logging/AsyncConfig.java
+++ b/daycan-back/api/src/main/java/com/daycan/common/logging/AsyncConfig.java
@@ -1,4 +1,4 @@
-package com.daycan.logging;
+package com.daycan.common.logging;
 
 import java.util.concurrent.Executor;
 import org.springframework.context.annotation.Configuration;

--- a/daycan-back/api/src/main/java/com/daycan/common/logging/MdcCopyTaskDecorator.java
+++ b/daycan-back/api/src/main/java/com/daycan/common/logging/MdcCopyTaskDecorator.java
@@ -1,4 +1,4 @@
-package com.daycan.logging;
+package com.daycan.common.logging;
 
 import java.util.Map;
 import org.slf4j.MDC;

--- a/daycan-back/api/src/main/java/com/daycan/common/logging/MdcKey.java
+++ b/daycan-back/api/src/main/java/com/daycan/common/logging/MdcKey.java
@@ -1,4 +1,4 @@
-package com.daycan.logging;
+package com.daycan.common.logging;
 
 /**
  * MDC에서 사용하는 키 정의

--- a/daycan-back/api/src/main/java/com/daycan/common/logging/MdcLoggingInterceptor.java
+++ b/daycan-back/api/src/main/java/com/daycan/common/logging/MdcLoggingInterceptor.java
@@ -1,4 +1,4 @@
-package com.daycan.logging;
+package com.daycan.common.logging;
 
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/daycan-back/api/src/main/java/com/daycan/common/logging/WebConfig.java
+++ b/daycan-back/api/src/main/java/com/daycan/common/logging/WebConfig.java
@@ -1,4 +1,4 @@
-package com.daycan.logging;
+package com.daycan.common.logging;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;

--- a/daycan-back/api/src/main/java/com/daycan/common/response/ApiResponse.java
+++ b/daycan-back/api/src/main/java/com/daycan/common/response/ApiResponse.java
@@ -1,0 +1,33 @@
+package com.daycan.common.response;
+
+import com.daycan.common.response.status.ErrorStatus;
+import com.daycan.common.response.status.SuccessStatus;
+
+public record ApiResponse<T>(
+    int status,
+    String message,
+    T result
+) {
+  public static final ApiResponse<Void> OK = new ApiResponse<>(
+      SuccessStatus.OK.getHttpStatus().value(),
+      SuccessStatus.OK.getMessage(),
+      null
+  );
+
+  public static <T> ApiResponse<T> onSuccess(T result) {
+    return new ApiResponse<>(
+        SuccessStatus.OK.getHttpStatus().value(),
+        SuccessStatus.OK.getMessage(),
+        result
+    );
+  }
+
+  public static <T> ApiResponse<T> onFailure(ErrorStatus errorStatus, T data) {
+    return new ApiResponse<>(
+        errorStatus.getHttpStatus().value(),
+        errorStatus.getMessage(),
+        data
+    );
+  }
+}
+

--- a/daycan-back/api/src/main/java/com/daycan/common/response/status/ErrorStatus.java
+++ b/daycan-back/api/src/main/java/com/daycan/common/response/status/ErrorStatus.java
@@ -1,0 +1,20 @@
+package com.daycan.common.response.status;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorStatus {
+  BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+  INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+  // 필요 시 추가
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  ErrorStatus(HttpStatus httpStatus, String message) {
+    this.httpStatus = httpStatus;
+    this.message = message;
+  }
+
+}

--- a/daycan-back/api/src/main/java/com/daycan/common/response/status/SuccessStatus.java
+++ b/daycan-back/api/src/main/java/com/daycan/common/response/status/SuccessStatus.java
@@ -1,0 +1,18 @@
+package com.daycan.common.response.status;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum SuccessStatus {
+  OK(HttpStatus.OK, "응답 성공");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  SuccessStatus(HttpStatus httpStatus, String message) {
+    this.httpStatus = httpStatus;
+    this.message = message;
+  }
+
+}


### PR DESCRIPTION
## 관련 이슈
해결한 문제를 지정하는 Issue Index에 연결해야 합니다.

- Resolves : #29 
 
## 작업 사항
해당 Pull Request에서 수행한 작업 목록을 제시해야 합니다.

### ApiResponse
- [x] `ApiResponse<T>` 제네릭 응답 객체 정의
- [x] `SuccessStatus` enum 정의
- [x] `ErrorStatus` enum 정의 (code, message, HttpStatus 포함)

