### PR TITLE
Feature/fe/#38 디자인 시스템 최종점검 과 segemet 컴포넌트 제작

### DIFF
--- a/daycan-front/apps/client/src/pages/ComponentTest.tsx
+++ b/daycan-front/apps/client/src/pages/ComponentTest.tsx
@@ -1,17 +1,23 @@
 import { Body, Button, Chip, Icon } from "@daycan/ui";
 import { COLORS } from "@daycan/ui";
-import { Input } from "@daycan/ui";
+import { Input, Segment } from "@daycan/ui";
+import { useState } from "react";
 
-export const ChipInputTest = () => {
+export const ComponentTest = () => {
+  const [selectedFood, setSelectedFood] = useState("일반식");
+  const [selectedPeriod, setSelectedPeriod] = useState("1주");
+
   return (
     <div style={{ 
-      backgroundColor: COLORS.gray[100],
+      backgroundColor: COLORS.gray[200],
       padding: "20px", 
       display: "flex", 
       flexDirection: "column", 
       gap: "24px",
       margin: "0 auto"
     }}>
+      
+
       <h2>Chip 컴포넌트 테스트</h2>
 
       {/* Basic Chip Variants */}
@@ -215,46 +221,111 @@ export const ChipInputTest = () => {
     <div style={{ 
       backgroundColor: COLORS.gray[100],
     }}>
-      <h2>Input 컴포넌트 테스트</h2>
-      <Input variant="pcInputFile">
+      <h2>Input 컴포넌트 테스트 (새로운 variant/size 구조)</h2>
+      
+      {/* PC Input File - White background */}
+      <Input variant="white" size="pcInputFile">
         <Body type="large" weight={600} color={COLORS.gray[800]}>
           label
         </Body>
         <Button variant="primary" size="small">등록</Button>
       </Input>
-      <Input variant="pcInputFile">
+      
+      <Input variant="white" size="pcInputFile">
         <Body type="large" weight={600} color={COLORS.gray[800]}>
           label
         </Body>
         <Button variant="error" size="small">삭제</Button>
       </Input>
-      <Input variant="moTextField">
+      
+      {/* Mobile Text Field - Gray background */}
+      <Input variant="grayLight" size="moTextField">
         <Body type="medium" weight={500} color={COLORS.gray[800]}>
           label
         </Body>
       </Input>
-      <Input variant="pcTextFieldLarge">
+      
+      {/* PC Text Field Large - Gray background */}
+      <Input variant="grayLight" size="pcTextFieldLarge">
         <Body type="medium" weight={500} color={COLORS.gray[800]}>
           label
         </Body>
       </Input>
-      <Input variant="pcTextField">
+      
+      {/* PC Text Field - White background */}
+      <Input variant="white" size="pcTextField">
         <Body type="medium" weight={500} color={COLORS.gray[800]}>
           label
         </Body>
       </Input>
-      <Input variant="textSearch" flexRule="none">
+      
+      {/* Text Search - White background */}
+      <Input variant="white" size="textSearch" flexRule="none">
         <Icon name="search" size={16} color={COLORS.gray[500]} stroke={COLORS.gray[500]} />
         <Body type="medium" weight={500} color={COLORS.gray[800]}>
           label
         </Body>
       </Input>
-      <Input variant="allTextFieldSmall" flexRule="center">
+      
+      {/* Small Text Field - White background */}
+      <Input variant="white" size="allTextFieldSmall" flexRule="center">
         <Body type="medium" weight={500} color={COLORS.gray[800]}>
           label
         </Body>
       </Input>
+      
+      {/* Full size with custom dimensions */}
+      <Input variant="white" size="full" flexRule="center" style={{ width: '1100px', height: '56px' }}>
+        <Body type="medium" weight={500} color={COLORS.gray[800]}>
+          label
+        </Body>
+      </Input>
+      
+      {/* 같은 size, 다른 variant 비교 */}
+      <div style={{ display: "flex", gap: "12px", alignItems: "center" }}>
+        <Input variant="white" size="pcTextField">
+          <Body type="medium" weight={500} color={COLORS.gray[800]}>화이트</Body>
+        </Input>
+        <Input variant="grayLight" size="pcTextField">
+          <Body type="medium" weight={500} color={COLORS.gray[800]}>그레이</Body>
+        </Input>
+      </div>
     </div>
+    {/* Segment 컴포넌트 테스트 */}
+      <div style={{ 
+        padding: "20px",
+        borderRadius: "12px",
+        display: "flex", 
+        flexDirection: "column", 
+        gap: "24px",
+      }}>
+        <h2>Segment 컴포넌트 테스트</h2>
+        
+        {/* SegmentItem 사용 (기본) */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px", maxWidth: "250px" }}>
+          <h3>음식 타입 선택 (SegmentItem 사용)</h3>
+          <Segment
+            options={["일반식", "죽", "유동식"]}
+            value={selectedFood}
+            onChange={setSelectedFood}
+            variant="default"
+            useChip={true}
+          />
+        </div>
+
+        {/* Chip 사용 */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px", maxWidth: "250px" }}>
+          <h3>기간 선택 (Chip 사용)</h3>
+          <Segment
+            options={["1주", "1개월", "6개월"]}
+            value={selectedPeriod}
+            onChange={setSelectedPeriod}
+            variant="default"
+            useChip={false}
+          />
+        </div>
+
+      </div>
 
     </div>
   );

--- a/daycan-front/packages/ui/src/components/Button/Button.tsx
+++ b/daycan-front/packages/ui/src/components/Button/Button.tsx
@@ -1,9 +1,10 @@
 import type { HTMLAttributes, PropsWithChildren } from "react";
 import { classNames } from "../../utils";
 import { button, type ButtonVariants } from "./Button.css";
+import { CustomWidthHeightType } from "@/utils";
 
 export type ButtonProps = PropsWithChildren<
-  HTMLAttributes<HTMLButtonElement> & ButtonVariants
+  HTMLAttributes<HTMLButtonElement> & ButtonVariants & CustomWidthHeightType
 >;
 
 export const Button = ({
@@ -14,7 +15,9 @@ export const Button = ({
   ...props
 }: ButtonProps) => {
   return (
-    <button className={classNames(button({ variant, size }))} {...props}>
+    <button className={classNames(button({ variant, size }))} 
+    style={{ width: props.customWidth, height: props.customHeight }}
+    {...props}>
       {children}
     </button>
   );

--- a/daycan-front/packages/ui/src/components/Chip/Chip.css.ts
+++ b/daycan-front/packages/ui/src/components/Chip/Chip.css.ts
@@ -99,7 +99,17 @@ export const chip = recipe({
             paddingRight: '12px',
         },
         none:{}
-    }
+    },
+    selected: {
+      true: {
+        backgroundColor: COLORS.gray[600],
+        color: COLORS.gray[100],
+      },
+      false: {
+        backgroundColor: COLORS.gray[50],
+        color: COLORS.gray[500],
+      },
+    },
   },
   defaultVariants: {
     size: 'btnDefault',

--- a/daycan-front/packages/ui/src/components/Chip/Chip.tsx
+++ b/daycan-front/packages/ui/src/components/Chip/Chip.tsx
@@ -1,11 +1,11 @@
 import React, { PropsWithChildren, HTMLAttributes } from 'react';
 import { classNames } from "@/utils";
 import { chip, type ChipVariants } from "./Chip.css";
+import { CustomWidthHeightType } from "@/utils";
 
 export type ChipProps = PropsWithChildren<
   HTMLAttributes<HTMLDivElement> & 
-  ChipVariants & {
-    onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  ChipVariants & CustomWidthHeightType & {
     backgroundColor?: string;
   }
 >;
@@ -17,6 +17,7 @@ export const Chip = ({
   padding,
   flexRule,
   backgroundColor,
+  selected,
   ...props
 }: ChipProps) => {
 
@@ -26,10 +27,11 @@ export const Chip = ({
         chip({ 
           size, 
           padding,
-          flexRule
+          flexRule,
+          selected,
         }), 
       )}
-      style={{ backgroundColor }}
+      style={{ backgroundColor, width: props.customWidth, height: props.customHeight }}
       onClick={onClick}
       {...props}
     >

--- a/daycan-front/packages/ui/src/components/Input/Input.css.ts
+++ b/daycan-front/packages/ui/src/components/Input/Input.css.ts
@@ -15,42 +15,49 @@ export const input = recipe({
   },
   variants: {
     variant: {
-      pcInputFile: {
+      white: {
         backgroundColor: COLORS.white,
+      },
+      grayLight: {
+        backgroundColor: COLORS.gray[50],
+      },
+    },
+    size: {
+      pcInputFile: {
         padding: '12px 24px',
         width: '668px',
         height: '56px',
       },
       moTextField: {
-        backgroundColor: COLORS.gray[50],
         padding: '16px 20px',
         width: '358px',
         height: '56px',
       },
       pcTextField: {
-        backgroundColor: COLORS.white,
         padding: '0px 12px',
         width: '300px',
         height: '42px',
       },
       pcTextFieldLarge: {
-        backgroundColor: COLORS.gray[50],
         padding: '16px 24px',
         width: '532px',
         height: '64px',
       },
       textSearch: {
-        backgroundColor: COLORS.white,
         padding: '6px 12px',
         width: '256px',
         height: '40px',
       },
       allTextFieldSmall: {
-        backgroundColor: COLORS.white,
         padding: '0px 12px',
         width: '86px',
         height: '32px',
       },
+      // 모바일에서 사용을 하기 어려운 경우 직접 width, height를 지정해서 사용을 위한 full size
+      full: {
+        width: '100%',
+        height: '100%',
+      }
     },
     flexRule: {
       center: {
@@ -59,11 +66,12 @@ export const input = recipe({
       spaceBetween: {
         justifyContent: 'space-between',
       },
-      none:{}
+      none: {}
     },
   },
   defaultVariants: {
-    variant: 'pcTextField',
+    variant: 'white',
+    size: 'full',
     flexRule: 'spaceBetween',
   },
 });

--- a/daycan-front/packages/ui/src/components/Input/Input.tsx
+++ b/daycan-front/packages/ui/src/components/Input/Input.tsx
@@ -1,18 +1,19 @@
 import React, { PropsWithChildren, HTMLAttributes } from 'react';
 import { classNames } from "@/utils";
 import { input, type InputVariants } from "./Input.css"; 
+import { CustomWidthHeightType } from "@/utils";
 
 export type InputProps = PropsWithChildren<
   HTMLAttributes<HTMLDivElement> & 
-  InputVariants & {
-    onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
-  }
+  InputVariants & 
+  CustomWidthHeightType 
 >;
 
 /* 
     Input 컴포넌트입니다.
     @param onClick - 클릭 이벤트 핸들러
-    @param variant - Input 스타일 변형
+    @param variant - Input 배경색 스타일 (white, grayLight)
+    @param size - Input 크기 및 패딩
     @param flexRule - Flexbox 정렬 규칙
     @param children - Input 내부에 렌더링할 자식 요소
     @param className - 추가 클래스명
@@ -23,6 +24,7 @@ export type InputProps = PropsWithChildren<
 export const Input = ({
     onClick,
     variant,
+    size,
     flexRule,
     children,
     className,
@@ -32,9 +34,10 @@ export const Input = ({
   return (
     <div
       className={classNames(
-        input({ variant, flexRule }), 
+        input({ variant, size, flexRule }), 
         className
       )}
+      style={{ width: props.customWidth, height: props.customHeight }}
       onClick={onClick}
       {...props}
     >

--- a/daycan-front/packages/ui/src/components/Segment/ChipSegment/ChipSegment.tsx
+++ b/daycan-front/packages/ui/src/components/Segment/ChipSegment/ChipSegment.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Chip } from '../../Chip';
+import { Body } from '../../Body';
+import { COLORS } from '@/styles/colors';
+
+interface ChipSegmentProps {
+  options: string[];
+  value: string;
+  onChange: (val: string) => void;
+}
+
+/**
+ * ChipSegment 컴포넌트는 Chip 컴포넌트를 사용하여 옵션을 표시합니다.
+ * @param options - 선택 가능한 옵션들
+ * @param value - 현재 선택된 값
+ * @param onChange - 값 변경 핸들러
+ * @returns ChipSegment 컴포넌트
+ */
+
+export const ChipSegment = ({ options, value, onChange }: ChipSegmentProps) => {
+  return (
+    <>
+      {options.map((option: string) => {
+        const isSelected = value === option;
+        
+        return (
+          <Chip 
+            key={option}
+            selected={isSelected}
+            onClick={() => onChange(option)}
+            size="btnXsmall"
+            padding="btnXsmall"
+            flexRule="center"
+          >
+            <Body 
+              type="xsmall" 
+              weight={500} 
+              color={isSelected ? COLORS.white : COLORS.gray[800]}
+            >
+              {option}
+            </Body>
+          </Chip>
+        );
+      })}
+    </>
+  );
+};

--- a/daycan-front/packages/ui/src/components/Segment/ChipSegment/index.ts
+++ b/daycan-front/packages/ui/src/components/Segment/ChipSegment/index.ts
@@ -1,0 +1,1 @@
+export * from './ChipSegment';

--- a/daycan-front/packages/ui/src/components/Segment/ItemSegment/ItemSegment.tsx
+++ b/daycan-front/packages/ui/src/components/Segment/ItemSegment/ItemSegment.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { SegmentItem } from './SegmentItem';
+import { Body } from '../../Body';
+import { COLORS } from '@/styles/colors';
+
+interface ItemSegmentProps {
+  options: string[];
+  value: string;
+  onChange: (val: string) => void;
+}
+
+/**
+ * ItemSegment 컴포넌트는 SegmentItem 컴포넌트를 사용하여 옵션을 표시합니다.
+ * @param options - 선택 가능한 옵션들
+ * @param value - 현재 선택된 값
+ * @param onChange - 값 변경 핸들러
+ * @returns ItemSegment 컴포넌트
+ */
+
+export const ItemSegment = ({ options, value, onChange }: ItemSegmentProps) => {
+  return (
+    <>
+      {options.map((option: string, index: number) => {
+        const isSelected = value === option;
+        const isNextSelected = index < options.length - 1 && value === options[index + 1];
+
+        return (
+          <React.Fragment key={option}>
+            <SegmentItem 
+              selected={isSelected}
+              onClick={() => onChange(option)}
+            >
+              <Body 
+                type="xsmall" 
+                weight={500} 
+                color={isSelected ? COLORS.gray[800] : COLORS.gray[600]}
+              >
+                {option}
+              </Body>
+            </SegmentItem>
+            {/* 마지막 아이템이 아닌 경우 divider 추가 */}
+            {index < options.length - 1 && (
+              <div 
+                style={{
+                  width: '1px',
+                  height: '24px',
+                  backgroundColor: (isSelected || isNextSelected) ? 'transparent' : COLORS.gray[400],
+                  transition: 'background-color 0.2s ease',
+                  alignSelf: 'center',
+                }}
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+};

--- a/daycan-front/packages/ui/src/components/Segment/ItemSegment/SegmentItem/SegmentItem.css.ts
+++ b/daycan-front/packages/ui/src/components/Segment/ItemSegment/SegmentItem/SegmentItem.css.ts
@@ -1,0 +1,55 @@
+import { COLORS } from "@/styles";
+import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
+
+export const segmentItem = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '3px 10px',
+    borderRadius: '20px',
+    cursor: 'pointer',
+    userSelect: 'none',
+    width: '118px',
+    height: '32px',
+  },
+  variants: {
+    selected: {
+      true: {
+        backgroundColor: COLORS.white,
+        color: COLORS.gray[800],
+      },
+      false: {
+        backgroundColor: 'transparent',
+        color: COLORS.gray[600],
+      },
+    },
+    size:{
+        btnXsmall: {
+            fontSize: '12px',
+            padding: '4px 8px',
+        }
+    },
+    padding: {
+      btnXsmall: {
+        padding: '4px 8px',
+      },
+    },
+    flexRule: {
+      center: {
+        justifyContent: 'center',
+      },
+      spaceBetween: {
+        justifyContent: 'space-between',
+      },
+    }, 
+  },
+  defaultVariants: {
+    size: 'btnXsmall',
+    padding: 'btnXsmall',
+    flexRule: 'center',
+    selected: false,
+  },
+});
+
+export type SegmentItemVariants = RecipeVariants<typeof segmentItem>;

--- a/daycan-front/packages/ui/src/components/Segment/ItemSegment/SegmentItem/SegmentItem.tsx
+++ b/daycan-front/packages/ui/src/components/Segment/ItemSegment/SegmentItem/SegmentItem.tsx
@@ -1,0 +1,29 @@
+import React, { HTMLAttributes } from 'react';
+import { classNames } from '@/utils';
+import { segmentItem, type SegmentItemVariants } from './SegmentItem.css';
+
+export type SegmentItemProps = HTMLAttributes<HTMLDivElement> & SegmentItemVariants;
+
+/**
+ * SegmentItem 컴포넌트는 Segment의 각 아이템을 나타냅니다.
+ * Chip컴포넌트와 다르게 SegmentItem은 ItemSegment내에서만 사용하므로 해당 위치에 작성합니다.
+ * @param selected - 현재 선택된 상태
+ * @returns SegmentItem 컴포넌트
+ */
+
+export const SegmentItem = ({
+  children,
+  selected,
+  onClick,
+  ...props
+}: SegmentItemProps) => {
+  return (
+    <div
+      className={classNames(segmentItem({ selected }))}
+      onClick={onClick}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};

--- a/daycan-front/packages/ui/src/components/Segment/ItemSegment/SegmentItem/index.ts
+++ b/daycan-front/packages/ui/src/components/Segment/ItemSegment/SegmentItem/index.ts
@@ -1,0 +1,1 @@
+export * from './SegmentItem';

--- a/daycan-front/packages/ui/src/components/Segment/ItemSegment/index.ts
+++ b/daycan-front/packages/ui/src/components/Segment/ItemSegment/index.ts
@@ -1,0 +1,1 @@
+export * from './ItemSegment';

--- a/daycan-front/packages/ui/src/components/Segment/Segment.css.ts
+++ b/daycan-front/packages/ui/src/components/Segment/Segment.css.ts
@@ -1,0 +1,38 @@
+import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
+import { COLORS } from '@/styles/colors';
+
+export const segment = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor: 'transparent',
+    borderRadius: '12px',
+    boxSizing: 'border-box',
+  },
+  variants: {
+    variant: {
+      default: {
+        flexDirection: 'row',
+        justifyContent: 'center',
+      },
+      vertical: {
+        flexDirection: 'column',
+        alignItems: 'stretch',
+      },
+    },
+    useChip: {
+      true: {
+        gap: '8px',
+      },
+      false: {
+        gap: '0px',
+      },
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    useChip: true,
+  },
+});
+
+export type SegmentVariants = RecipeVariants<typeof segment>;

--- a/daycan-front/packages/ui/src/components/Segment/Segment.tsx
+++ b/daycan-front/packages/ui/src/components/Segment/Segment.tsx
@@ -1,0 +1,59 @@
+import React, { PropsWithChildren, HTMLAttributes } from 'react';
+import { classNames } from "@/utils";
+
+import { segment, type SegmentVariants } from "./Segment.css";
+import { CustomWidthHeightType } from "@/utils";
+import { ChipSegment } from './ChipSegment';
+import { ItemSegment } from './ItemSegment';
+
+export type SegmentProps = PropsWithChildren<
+  Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> & 
+  SegmentVariants & 
+  CustomWidthHeightType & {
+    options: string[];
+    value: string;
+    onChange: (val: string) => void;
+  }
+>;
+
+/* 
+    Segment 컴포넌트입니다.
+    @param variant - Segment 스타일 변형
+    @param options - 선택 가능한 옵션들
+    @param value - 현재 선택된 값
+    @param onChange - 값 변경 핸들러
+    @param useChip - true면 Chip 컴포넌트 사용, false면 SegmentItem 컴포넌트 사용 (기본값: false)
+    @returns Segment 컴포넌트
+*/
+
+export const Segment = ({
+  variant,
+  children,
+  options,
+  onChange,
+  value,
+  useChip = false,
+  ...props
+}: SegmentProps) => {
+  return (
+    <div
+      className={classNames(segment({ variant, useChip }))}
+      style={{ width: props.customWidth, height: props.customHeight }}
+      {...props}
+    >
+      {useChip ? (
+        <ChipSegment 
+          options={options}
+          value={value}
+          onChange={onChange}
+        />
+      ) : (
+        <ItemSegment 
+          options={options}
+          value={value}
+          onChange={onChange}
+        />
+      )}
+    </div>
+  );
+};

--- a/daycan-front/packages/ui/src/components/Segment/index.ts
+++ b/daycan-front/packages/ui/src/components/Segment/index.ts
@@ -1,0 +1,1 @@
+export * from "./Segment";

--- a/daycan-front/packages/ui/src/components/index.ts
+++ b/daycan-front/packages/ui/src/components/index.ts
@@ -20,3 +20,4 @@ export * from "./Button";
 export * from "./CircularProgress";
 export * from "./Chip";
 export * from "./Input";
+export * from "./Segment";

--- a/daycan-front/packages/ui/src/utils/customWidthHeightType.ts
+++ b/daycan-front/packages/ui/src/utils/customWidthHeightType.ts
@@ -1,0 +1,8 @@
+/* 
+    커스텀 너비와 높이를 위한 타입입니다.
+*/
+
+export type CustomWidthHeightType = {
+  customWidth?: string | number;
+  customHeight?: string | number;
+};

--- a/daycan-front/packages/ui/src/utils/index.ts
+++ b/daycan-front/packages/ui/src/utils/index.ts
@@ -5,3 +5,4 @@
  */
 export * from "./getColorValue";
 export * from "./classNames";
+export * from "./customWidthHeightType";


### PR DESCRIPTION
## 관련 이슈
- Resolves : #38 
 
## 작업 사항

https://github.com/user-attachments/assets/e0dfe99d-1d91-4b5c-8bf8-20d465152386

### segment 컴포넌트 제작
- segment 컴포넌트가 두 종류 있기 때문에 SegmentItem 컴포넌트를 정의해서 SementItem을 사용하는 ItemSegment와 Chip컴포넌트를 사용하는 ChipSegment컴포넌트를 제작해 Segment컴포넌트에서 조합해 사용했습니다.
<img width="209" height="233" alt="image" src="https://github.com/user-attachments/assets/694bf16f-2fd9-45cc-8fb9-6f837d35d377" />      

Segment 컴포넌트 구조 입니다.

### 디자인 시스템 점검 특이사항
- 모바일의 경우 공통 컴포넌트에 정의 된 내용과 다른 width와 height이 제각각 다른 픽셀값이 들어가 있는 것을 확인했습니다.
<img width="304" height="160" alt="image" src="https://github.com/user-attachments/assets/c3612f44-8c8c-456c-a57e-59de8a362620" />
<img width="356" height="130" alt="image" src="https://github.com/user-attachments/assets/e42f4f65-cb39-4342-bcd4-144d06f76ca3" />
- customWidthHeight을 받아 특이사항이 생길 경우 외부에서 값을 주입할 수 있도록 하였습니다.

## 참고 사항
이전 PR에서 Input css의 varient에서 color와 size를 분리하라 하셔서 완료하였습니다.
