### PR TITLE
Feature/fe/#109 - 기록지 및 리포트 내역 모아보기 기능 구현

### DIFF
--- a/daycan-front/apps/admin/src/components/CareSheetDataSummaryCard/CareSheetDataSummaryCard.css.ts
+++ b/daycan-front/apps/admin/src/components/CareSheetDataSummaryCard/CareSheetDataSummaryCard.css.ts
@@ -1,0 +1,44 @@
+import { COLORS } from "@daycan/ui";
+import { style } from "@vanilla-extract/css";
+
+export const summaryCardContainer = style({
+  marginBottom: "20px",
+  padding: "16px",
+  border: `1px solid ${COLORS.gray[200]}`,
+  borderRadius: "8px",
+  backgroundColor: COLORS.white,
+});
+
+export const summaryCardTitle = style({
+  marginBottom: "12px",
+});
+
+export const summaryCardItemsGrid = style({
+  display: "grid",
+  gridTemplateColumns: "repeat(2, 1fr)",
+  gap: "8px",
+});
+
+export const summaryCardItemsColumn = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+});
+
+export const summaryCardItem = style({
+  // 기본 스타일은 Body 컴포넌트에서 처리되므로 여기서는 추가 스타일만 정의
+});
+
+// 3열 그리드용 스타일
+export const summaryCardItemsGrid3 = style({
+  display: "grid",
+  gridTemplateColumns: "repeat(3, 1fr)",
+  gap: "8px",
+});
+
+// 4열 그리드용 스타일
+export const summaryCardItemsGrid4 = style({
+  display: "grid",
+  gridTemplateColumns: "repeat(4, 1fr)",
+  gap: "8px",
+});

--- a/daycan-front/apps/admin/src/components/CareSheetDataSummaryCard/CareSheetDataSummaryCard.tsx
+++ b/daycan-front/apps/admin/src/components/CareSheetDataSummaryCard/CareSheetDataSummaryCard.tsx
@@ -1,0 +1,111 @@
+import { Body, COLORS } from "@daycan/ui";
+import {
+  summaryCardContainer,
+  summaryCardTitle,
+  summaryCardItemsGrid,
+  summaryCardItemsColumn,
+  summaryCardItemsGrid3,
+  summaryCardItemsGrid4,
+  summaryCardItem,
+} from "./CareSheetDataSummaryCard.css";
+
+interface CareSheetDataSummaryCardProps {
+  title: string;
+  icon: string;
+  items: Array<{
+    label: string;
+    value: string | number | boolean;
+    unit?: string;
+    booleanLabels?: { true: string; false: string };
+  }>;
+  layout?: "grid" | "column";
+  gridColumns?: number;
+}
+
+export const CareSheetDataSummaryCard = ({
+  title,
+  icon,
+  items,
+  layout = "grid",
+  gridColumns = 2,
+}: CareSheetDataSummaryCardProps) => {
+  const formatValue = (
+    value: string | number | boolean,
+    unit?: string,
+    booleanLabels?: { true: string; false: string }
+  ) => {
+    if (typeof value === "boolean") {
+      return booleanLabels
+        ? value
+          ? booleanLabels.true
+          : booleanLabels.false
+        : value
+          ? "예"
+          : "아니오";
+    }
+
+    if (unit) {
+      return `${value}${unit}`;
+    }
+
+    return value;
+  };
+
+  const renderItems = () => {
+    if (layout === "column") {
+      return (
+        <div className={summaryCardItemsColumn}>
+          {items.map((item, index) => (
+            <div key={index} className={summaryCardItem}>
+              <Body type="xsmall" weight={500} color={COLORS.gray[600]}>
+                {item.label}:
+              </Body>
+              <Body type="xsmall" weight={600} color={COLORS.gray[800]}>
+                {formatValue(item.value, item.unit, item.booleanLabels)}
+              </Body>
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <div
+        className={
+          gridColumns === 2
+            ? summaryCardItemsGrid
+            : gridColumns === 3
+              ? summaryCardItemsGrid3
+              : gridColumns === 4
+                ? summaryCardItemsGrid4
+                : summaryCardItemsGrid
+        }
+      >
+        {items.map((item, index) => (
+          <div key={index} className={summaryCardItem}>
+            <Body type="xsmall" weight={500} color={COLORS.gray[600]}>
+              {item.label}:
+            </Body>
+            <Body type="xsmall" weight={600} color={COLORS.gray[800]}>
+              {formatValue(item.value, item.unit, item.booleanLabels)}
+            </Body>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className={summaryCardContainer}>
+      <Body
+        type="small"
+        weight={600}
+        color={COLORS.gray[700]}
+        className={summaryCardTitle}
+      >
+        {icon} {title}
+      </Body>
+      {renderItems()}
+    </div>
+  );
+};

--- a/daycan-front/apps/admin/src/components/CareSheetDataSummaryCard/index.ts
+++ b/daycan-front/apps/admin/src/components/CareSheetDataSummaryCard/index.ts
@@ -1,0 +1,7 @@
+/**
+ * CareSheetDataSummaryCard 컴포넌트는 케어시트 데이터를 요약해서 표시하는 컴포넌트입니다.
+ * CareSheetDataView 컴포넌트에서 여러차례 사용되며, 여러 key-value 쌍을 표시할 때 사용됩니다.
+ * grid, column 에 따라 각기 다른 layout 을 사용할 수 있습니다.
+ * @author 홍규진
+ */
+export * from "./CareSheetDataSummaryCard";

--- a/daycan-front/apps/admin/src/components/CareSheetDataView/CareSheetDataView.tsx
+++ b/daycan-front/apps/admin/src/components/CareSheetDataView/CareSheetDataView.tsx
@@ -1,0 +1,218 @@
+import { Body, COLORS } from "@daycan/ui";
+import type { CareSheetHistoryData } from "../../pages/member/components/HistoryModal/useHistoryModal";
+import { CareSheetDataSummaryCard } from "@/components/CareSheetDataSummaryCard";
+import {
+  MEAL_TYPE_CODE_TO_LABEL,
+  MEAL_AMOUNT_CODE_TO_LABEL,
+} from "@/pages/care-sheet/funnels/diagnosis-funnel/constants/diagnosis";
+
+interface CareSheetDataViewProps {
+  careSheetData: CareSheetHistoryData | null;
+}
+
+export const CareSheetDataView = ({
+  careSheetData,
+}: CareSheetDataViewProps) => {
+  return (
+    <div>
+      <Body
+        type="medium"
+        weight={600}
+        color={COLORS.gray[900]}
+        style={{ marginBottom: "16px" }}
+      >
+        📝 관리 기록지 상세 내용
+      </Body>
+
+      {/* 기본 정보 요약 */}
+      <CareSheetDataSummaryCard
+        title="기본 정보 요약"
+        icon="👤"
+        items={[
+          {
+            label: "수급자 ID",
+            value: careSheetData?.recipientId || "",
+          },
+          { label: "이용 날짜", value: careSheetData?.date || "" },
+          {
+            label: "시작 시간",
+            value: careSheetData?.startTime || "",
+          },
+          {
+            label: "종료 시간",
+            value: careSheetData?.endTime || "",
+          },
+          {
+            label: "이동 서비스",
+            value: careSheetData?.mobilityNumber
+              ? `차량번호: ${careSheetData.mobilityNumber}`
+              : "미이용",
+          },
+        ]}
+      />
+
+      {/* 진단 정보 요약 */}
+      <CareSheetDataSummaryCard
+        title="진단 정보 요약"
+        icon="🏥"
+        items={[
+          {
+            label: "혈압",
+            value:
+              careSheetData?.healthCare?.bloodPressure?.systolic &&
+              careSheetData?.healthCare?.bloodPressure?.diastolic
+                ? `${careSheetData.healthCare.bloodPressure.systolic}/${careSheetData.healthCare.bloodPressure.diastolic}`
+                : "측정 안함",
+            unit:
+              careSheetData?.healthCare?.bloodPressure?.systolic &&
+              careSheetData?.healthCare?.bloodPressure?.diastolic
+                ? " mmHg"
+                : "",
+          },
+          {
+            label: "체온",
+            value: careSheetData?.healthCare?.temperature || 0,
+            unit: "℃",
+          },
+          {
+            label: "소변 횟수",
+            value: careSheetData?.physical?.numberOfUrine || 0,
+            unit: "회",
+          },
+          {
+            label: "대변 횟수",
+            value: careSheetData?.physical?.numberOfStool || 0,
+            unit: "회",
+          },
+        ]}
+      />
+
+      {/* 신체 활동 정보 */}
+      <CareSheetDataSummaryCard
+        title="신체 활동 정보"
+        icon="🚶"
+        items={[
+          {
+            label: "세면 보조",
+            value: careSheetData?.physical?.assistWashing || false,
+          },
+          {
+            label: "이동 보조",
+            value: careSheetData?.physical?.assistMovement || false,
+          },
+          {
+            label: "목욕 보조",
+            value: careSheetData?.physical?.assistBathing || false,
+          },
+          {
+            label: "목욕 시간",
+            value: careSheetData?.physical?.bathingDurationMinutes
+              ? `${careSheetData.physical.bathingDurationMinutes}분`
+              : "없음",
+          },
+          {
+            label: "목욕 방식",
+            value: careSheetData?.physical?.bathingType || "없음",
+          },
+        ]}
+      />
+
+      {/* 식사 정보 */}
+      <CareSheetDataSummaryCard
+        title="식사 정보"
+        icon="🍽️"
+        items={[
+          {
+            label: "아침 식사",
+            value: careSheetData?.physical?.breakfast?.provided
+              ? `제공 (${MEAL_TYPE_CODE_TO_LABEL[careSheetData.physical.breakfast.entry.mealType] || careSheetData.physical.breakfast.entry.mealType}, ${MEAL_AMOUNT_CODE_TO_LABEL[careSheetData.physical.breakfast.entry.amount] || careSheetData.physical.breakfast.entry.amount})`
+              : "미제공",
+          },
+          {
+            label: "점심 식사",
+            value: careSheetData?.physical?.lunch?.provided
+              ? `제공 (${MEAL_TYPE_CODE_TO_LABEL[careSheetData.physical.lunch.entry.mealType] || careSheetData.physical.lunch.entry.mealType}, ${MEAL_AMOUNT_CODE_TO_LABEL[careSheetData.physical.lunch.entry.amount] || careSheetData.physical.lunch.entry.amount})`
+              : "미제공",
+          },
+          {
+            label: "저녁 식사",
+            value: careSheetData?.physical?.dinner?.provided
+              ? `제공 (${MEAL_TYPE_CODE_TO_LABEL[careSheetData.physical.dinner.entry.mealType] || careSheetData.physical.dinner.entry.mealType}, ${MEAL_AMOUNT_CODE_TO_LABEL[careSheetData.physical.dinner.entry.amount] || careSheetData.physical.dinner.entry.amount})`
+              : "미제공",
+          },
+        ]}
+      />
+
+      {/* 추가 진단 정보 */}
+      <CareSheetDataSummaryCard
+        title="추가 진단 정보"
+        icon="💊"
+        items={[
+          {
+            label: "건강 관리",
+            value: careSheetData?.healthCare?.healthCare || false,
+          },
+          {
+            label: "간호 관리",
+            value: careSheetData?.healthCare?.nursingCare || false,
+          },
+          {
+            label: "응급 서비스",
+            value: careSheetData?.healthCare?.emergencyService || false,
+          },
+        ]}
+      />
+
+      {/* 회복 프로그램 정보 */}
+      <CareSheetDataSummaryCard
+        title="회복 프로그램 정보"
+        icon="🎯"
+        items={[
+          {
+            label: "운동 훈련",
+            value: careSheetData?.recoveryProgram?.motionTraining || false,
+          },
+          {
+            label: "인지 프로그램",
+            value: careSheetData?.recoveryProgram?.cognitiveProgram || false,
+          },
+          {
+            label: "물리 치료",
+            value: careSheetData?.recoveryProgram?.physicalTherapy || false,
+          },
+          {
+            label: "프로그램 참여도",
+            value:
+              careSheetData?.recoveryProgram?.programEntries?.[0]?.score ||
+              "평가 없음",
+          },
+        ]}
+      />
+
+      {/* 특이사항 및 코멘트 */}
+      <CareSheetDataSummaryCard
+        title="특이사항 및 코멘트"
+        icon="📝"
+        items={[
+          {
+            label: "신체 활동 코멘트",
+            value: careSheetData?.physical?.comment || "없음",
+          },
+          {
+            label: "인지 활동 코멘트",
+            value: careSheetData?.cognitive?.comment || "없음",
+          },
+          {
+            label: "건강 관리 코멘트",
+            value: careSheetData?.healthCare?.comment || "없음",
+          },
+          {
+            label: "회복 프로그램 코멘트",
+            value: careSheetData?.recoveryProgram?.comment || "없음",
+          },
+        ]}
+        layout="column"
+      />
+    </div>
+  );
+};

--- a/daycan-front/apps/admin/src/components/CareSheetDataView/index.ts
+++ b/daycan-front/apps/admin/src/components/CareSheetDataView/index.ts
@@ -1,0 +1,7 @@
+/**
+ * CareSheetDataView 컴포넌트는 케어시트 데이터를 표시하는 컴포넌트입니다.
+ * API 요청을 통해 받은 CareSheet(기록지) 데이터를 파싱해 보기 좋게 표시합니다.
+ * 해당 컴포넌트는 Member 페이지에서 케어시트 기록을 볼 때, 검토할 때 사용됩니다.
+ * @author 홍규진
+ */
+export * from "./CareSheetDataView";

--- a/daycan-front/apps/admin/src/components/ReportDataView/ReportDataView.css.ts
+++ b/daycan-front/apps/admin/src/components/ReportDataView/ReportDataView.css.ts
@@ -1,0 +1,11 @@
+import { style } from "@vanilla-extract/css";
+
+export const reportDataViewContainer = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "start",
+  justifyContent: "start",
+
+  boxSizing: "border-box",
+  gap: 5,
+});

--- a/daycan-front/apps/admin/src/components/ReportDataView/ReportDataView.tsx
+++ b/daycan-front/apps/admin/src/components/ReportDataView/ReportDataView.tsx
@@ -1,0 +1,84 @@
+import { Body, COLORS } from "@daycan/ui";
+import {
+  HealthIndexCard,
+  MealCard,
+  HealthCheckCard,
+  HealthImproveCard,
+  CognitiveCard,
+} from "../../../../client/src/pages/daily-report/components";
+import type { ReportHistoryData } from "../../pages/member/components/HistoryModal/useHistoryModal";
+import { reportDataViewContainer } from "./ReportDataView.css";
+
+interface ReportDataViewProps {
+  reportData: ReportHistoryData | null;
+}
+
+export const ReportDataView = ({ reportData }: ReportDataViewProps) => {
+  if (!reportData) {
+    return (
+      <div style={{ textAlign: "center", padding: "40px 0" }}>
+        <Body type="medium" weight={600} color={COLORS.gray[900]}>
+          리포트 데이터를 불러오는 중...
+        </Body>
+      </div>
+    );
+  }
+
+  return (
+    <div className={reportDataViewContainer}>
+      <Body
+        type="medium"
+        weight={600}
+        color={COLORS.gray[900]}
+        style={{ marginBottom: "16px" }}
+      >
+        📋 리포트 상세 내용
+      </Body>
+
+      <HealthIndexCard
+        index={reportData.totalScore}
+        description={`전체 점수: ${reportData.totalScore}점, 변화량: ${reportData.changeAmount}점`}
+        indexCardData={[
+          { title: "식사", value: reportData.mealScore },
+          { title: "건강", value: reportData.healthScore },
+          { title: "신체", value: reportData.physicalScore },
+          { title: "인지", value: reportData.cognitiveScore },
+        ]}
+        isDropdown={true}
+      />
+
+      <MealCard
+        isDropdown={true}
+        rows={reportData.mealEntries.map((entry) => ({
+          key: entry.key,
+          value: entry.value,
+          warningDescription: entry.warning,
+        }))}
+      />
+
+      <HealthCheckCard
+        isDropdown={true}
+        rows={reportData.healthEntries.map((entry) => ({
+          key: entry.key,
+          value: entry.value,
+        }))}
+      />
+
+      <HealthImproveCard
+        isDropdown={true}
+        columns={reportData.physicalEntries.map((entry) => ({
+          key: entry.key,
+          value: entry.value,
+        }))}
+      />
+
+      <CognitiveCard
+        isDropdown={true}
+        columns={reportData.cognitiveEntries.map((entry) => ({
+          key: entry.key,
+          value: entry.value,
+        }))}
+      />
+    </div>
+  );
+};

--- a/daycan-front/apps/admin/src/components/ReportDataView/index.ts
+++ b/daycan-front/apps/admin/src/components/ReportDataView/index.ts
@@ -1,0 +1,8 @@
+/**
+ * ReportDataView 컴포넌트를 내보내는 파일입니다.
+ * ReportDataView 컴포넌트는 리포트 데이터를 표시하는 컴포넌트입니다.
+ * API 요청을 통해 Report 데이터 단건 조회를 통해 받은 데이터를 파싱해 보기 좋게 표시합니다.
+ * 해당 컴포넌트는 Member 페이지에서 리포트 기록을 볼 때, 리포트 전송 전 검토할 때 사용됩니다.
+ * @author 홍규진
+ */
+export * from "./ReportDataView";

--- a/daycan-front/apps/admin/src/components/index.ts
+++ b/daycan-front/apps/admin/src/components/index.ts
@@ -5,3 +5,6 @@ export * from "./PageToolbar";
 export * from "./MenuItemHeader";
 export * from "./FilterSearchbar";
 export * from "./DropDownChip";
+export * from "./CareSheetDataSummaryCard";
+export * from "./ReportDataView";
+export * from "./CareSheetDataView";

--- a/daycan-front/apps/admin/src/index.tsx
+++ b/daycan-front/apps/admin/src/index.tsx
@@ -8,5 +8,6 @@ import { THEME } from "@daycan/ui";
 createRoot(document.getElementById("root")!).render(
   <div className={THEME}>
     <App />
+    <div id="modal-root" />
   </div>
 );

--- a/daycan-front/apps/admin/src/pages/care-sheet/components/CareSheetListItem/CareSheetListItem.tsx
+++ b/daycan-front/apps/admin/src/pages/care-sheet/components/CareSheetListItem/CareSheetListItem.tsx
@@ -31,6 +31,7 @@ const getStatusInfo = (status: string) => {
         text: "작성 완료",
         icon: "circleCheck",
         color: COLORS.blue[500],
+        strokeColor: COLORS.white,  
       };
     case "NOT_APPLICABLE":
       return {
@@ -101,6 +102,7 @@ export const CareSheetListItem = ({
             width={20}
             height={20}
             color={statusInfo.color}
+            stroke={statusInfo.strokeColor}
           />
         </div>
       </div>

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/info-funnel/steps/Step1/Step1.tsx
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/info-funnel/steps/Step1/Step1.tsx
@@ -97,6 +97,7 @@ export const Step1 = () => {
             width={24}
             height={24}
             color={isToday ? COLORS.primary[300] : COLORS.gray[50]}
+            stroke={COLORS.white}
           />
         </div>
         <div

--- a/daycan-front/apps/admin/src/pages/login/LoginPage.tsx
+++ b/daycan-front/apps/admin/src/pages/login/LoginPage.tsx
@@ -101,6 +101,7 @@ export const LoginPage = () => {
               width={16}
               height={16}
               color={isChecked ? COLORS.gray[900] : COLORS.gray[100]}
+              stroke={COLORS.white}
             />
             <Body type="small" weight={400} style={{ color: COLORS.gray[700] }}>
               로그인 상태 유지

--- a/daycan-front/apps/admin/src/pages/member/components/HistoryModal/HistoryModal.css.ts
+++ b/daycan-front/apps/admin/src/pages/member/components/HistoryModal/HistoryModal.css.ts
@@ -1,0 +1,215 @@
+import { COLORS } from "@daycan/ui";
+import { style } from "@vanilla-extract/css";
+
+export const historyModalContainer = style({
+  width: "840px",
+  height: "600px",
+});
+
+export const historyModalHeader = style({
+  display: "flex",
+  width: "100%",
+  height: "64px",
+  backgroundColor: COLORS.gray[700],
+  borderRadius: "8px 8px 0 0",
+  padding: "16px 24px",
+  justifyContent: "space-between",
+  alignItems: "center",
+});
+
+export const historyModalHeaderLeft = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "16px",
+});
+
+export const historyModalHeaderRight = style({
+  width: "167px",
+  height: "40px",
+  borderRadius: "50px",
+  display: "flex",
+  alignItems: "center",
+  backgroundColor: COLORS.gray[600],
+  padding: "8px 12px",
+  boxSizing: "border-box",
+  gap: "8px",
+});
+
+export const historyModalHeaderRightProfile = style({
+  width: "32px",
+  height: "32px",
+  border: `1px solid ${COLORS.gray[300]}`,
+  borderRadius: "50%",
+});
+
+export const historyModalHeaderDateSelect = style({
+  display: "flex",
+  alignItems: "center",
+  padding: "12px 16px",
+  boxSizing: "border-box",
+});
+
+export const historyModalContentContainer = style({
+  display: "flex",
+  height: "500px",
+  flexDirection: "row",
+  gap: "24px",
+  padding: "0px 24px 48px 24px",
+});
+
+export const historyModalContentLeft = style({
+  display: "flex",
+  width: "287px",
+  height: "100%",
+  padding: "24px 16px",
+  borderRadius: "12px",
+  boxSizing: "border-box",
+  flexDirection: "column",
+  backgroundColor: COLORS.gray[50],
+  gap: "16px",
+});
+
+export const historyModalContentRight = style({
+  display: "flex",
+  width: "489px",
+  height: "100%",
+  backgroundColor: COLORS.gray[50],
+  borderRadius: "12px",
+  padding: "24px 16px",
+  boxSizing: "border-box",
+});
+
+// 새로 추가된 스타일들
+export const dateSelectContainer = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "16px",
+  justifyContent: "center",
+  width: "100%",
+});
+
+export const monthSelector = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minWidth: "120px",
+});
+
+export const monthButton = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "32px",
+  height: "32px",
+  border: "none",
+  backgroundColor: "transparent",
+  cursor: "pointer",
+  borderRadius: "4px",
+  transition: "background-color 0.2s",
+  ":hover": {
+    backgroundColor: COLORS.gray[100],
+  },
+});
+
+export const dateListContainer = style({
+  display: "grid",
+  gridTemplateColumns: "repeat(7, 1fr)",
+  gap: "8px",
+  padding: "16px 0",
+});
+
+export const dateItem = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "32px",
+  height: "32px",
+  borderRadius: "50%",
+  cursor: "pointer",
+  transition: "all 0.2s",
+  border: `1px solid ${COLORS.gray[200]}`,
+  backgroundColor: COLORS.white,
+  ":hover": {
+    backgroundColor: COLORS.gray[100],
+    borderColor: COLORS.gray[300],
+  },
+});
+
+export const dateItemActive = style({
+  backgroundColor: COLORS.primary[300],
+  borderColor: COLORS.primary[300],
+  color: COLORS.white,
+});
+
+// 새로운 Left 영역 스타일들
+export const dateStatusListContainer = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "16px",
+  padding: "16px 0",
+  maxHeight: "400px",
+  overflowY: "auto",
+});
+
+export const dateStatusItem = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "12px",
+  padding: "16px",
+  backgroundColor: COLORS.white,
+  borderRadius: "8px",
+  border: `1px solid ${COLORS.gray[200]}`,
+});
+
+export const dateStatusHeader = style({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  gap: "12px",
+});
+
+export const dateStatusAttendance = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "32px",
+  height: "32px",
+  borderRadius: "50%",
+  backgroundColor: COLORS.green[500],
+  color: COLORS.white,
+});
+
+export const dateStatusContent = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+});
+
+export const statusItem = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "12px",
+  padding: "8px 12px",
+  backgroundColor: COLORS.gray[50],
+  borderRadius: "6px",
+});
+
+export const confirmButton = style({
+  border: "none",
+  backgroundColor: "transparent",
+  cursor: "pointer",
+  padding: "4px 8px",
+  borderRadius: "4px",
+  transition: "background-color 0.2s",
+  ":hover": {
+    backgroundColor: COLORS.gray[100],
+  },
+});
+
+export const reportContainer = style({
+  display: "flex",
+  flexDirection: "column",
+  overflowY: "auto",
+  width: "100%",
+});

--- a/daycan-front/apps/admin/src/pages/member/components/HistoryModal/HistoryModal.tsx
+++ b/daycan-front/apps/admin/src/pages/member/components/HistoryModal/HistoryModal.tsx
@@ -1,0 +1,288 @@
+import { Body, Chip, COLORS, Icon, Modal } from "@daycan/ui";
+import {
+  historyModalContainer,
+  historyModalHeader,
+  historyModalHeaderLeft,
+  historyModalHeaderRight,
+  historyModalHeaderDateSelect,
+  historyModalContentContainer,
+  historyModalContentLeft,
+  historyModalContentRight,
+  historyModalHeaderRightProfile,
+  dateSelectContainer,
+  monthSelector,
+  monthButton,
+  dateStatusListContainer,
+  dateStatusItem,
+  dateStatusHeader,
+  dateStatusContent,
+  statusItem,
+  confirmButton,
+  reportContainer,
+} from "./HistoryModal.css";
+import profileImg from "@/assets/images/profile.png";
+import { useState } from "react";
+
+import { useHistoryModal } from "./useHistoryModal";
+import { ReportDataView } from "@/components/ReportDataView";
+import { CareSheetDataView } from "@/components/CareSheetDataView";
+
+interface HistoryModalProps {
+  memberId?: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const HistoryModal = ({
+  memberId = "1",
+  isOpen,
+  onClose,
+}: HistoryModalProps) => {
+  const [selectedMonth, setSelectedMonth] = useState(new Date());
+
+  const {
+    historyData,
+    careSheetData,
+    isLoading,
+    fetchHistoryData,
+    fetchCareSheetData,
+  } = useHistoryModal();
+
+  const [selectedDataType, setSelectedDataType] = useState<
+    "report" | "careSheet" | null
+  >(null);
+
+  const handleViewReport = async (date: Date) => {
+    setSelectedDataType("report");
+    console.log("handleViewReport", date, memberId);
+    await fetchHistoryData(date, memberId);
+  };
+
+  const handleViewCareSheet = async (date: Date) => {
+    setSelectedDataType("careSheet");
+    console.log("handleViewCareSheet", date, memberId);
+    await fetchCareSheetData(date, memberId);
+  };
+
+  const getDaysInMonth = (date: Date) => {
+    const year = date.getFullYear();
+    const month = date.getMonth();
+    const lastDay = new Date(year, month + 1, 0);
+    const days = [];
+
+    for (let day = 1; day <= lastDay.getDate(); day++) {
+      days.push(new Date(year, month, day));
+    }
+
+    return days;
+  };
+
+  const changeMonth = (direction: "prev" | "next") => {
+    setSelectedMonth((prev) => {
+      const newMonth = new Date(prev);
+      if (direction === "prev") {
+        newMonth.setMonth(prev.getMonth() - 1);
+      } else {
+        newMonth.setMonth(prev.getMonth() + 1);
+      }
+      return newMonth;
+    });
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className={historyModalContainer}>
+        <div className={historyModalHeader}>
+          <div className={historyModalHeaderLeft}>
+            <Icon
+              name="smallLogo"
+              width={32}
+              height={32}
+              color={COLORS.white}
+            />
+            <Body type="large" weight={500} color={COLORS.white}>
+              기록지 리포트 내역
+            </Body>
+          </div>
+          <div className={historyModalHeaderRight}>
+            <img
+              src={profileImg}
+              alt="프로필"
+              className={historyModalHeaderRightProfile}
+            />
+            <Body type="xsmall" weight={500} color={COLORS.white}>
+              {/*TODO - API 로 수정 */}
+              김큐티빠띠할머니
+            </Body>
+          </div>
+        </div>
+
+        <div className={historyModalHeaderDateSelect}>
+          <div className={dateSelectContainer}>
+            <button className={monthButton} onClick={() => changeMonth("prev")}>
+              <Icon
+                name="chevronLeft"
+                width={16}
+                height={16}
+                color={COLORS.gray[600]}
+              />
+            </button>
+            <div className={monthSelector}>
+              <Body type="medium" weight={600} color={COLORS.gray[900]}>
+                {selectedMonth.getFullYear()}년 {selectedMonth.getMonth() + 1}월
+              </Body>
+            </div>
+            <button className={monthButton} onClick={() => changeMonth("next")}>
+              <Icon
+                name="chevronRight"
+                width={16}
+                height={16}
+                color={COLORS.gray[600]}
+              />
+            </button>
+          </div>
+        </div>
+
+        {/* 왼쪽 영역 */}
+        <div className={historyModalContentContainer}>
+          <div className={historyModalContentLeft}>
+            <Body type="medium" weight={600} color={COLORS.gray[900]}>
+              일별 기록 현황
+            </Body>
+            <div className={dateStatusListContainer}>
+              {getDaysInMonth(selectedMonth).map((date) => {
+                const dayOfWeek = ["일", "월", "화", "수", "목", "금", "토"][
+                  date.getDay()
+                ];
+                const isWeekend = dayOfWeek === "일" || dayOfWeek === "토";
+
+                return (
+                  <div key={date.getTime()} className={dateStatusItem}>
+                    <div className={dateStatusHeader}>
+                      <Body
+                        type="small"
+                        weight={600}
+                        color={isWeekend ? COLORS.red[500] : COLORS.gray[900]}
+                      >
+                        {date.getFullYear()}년 {date.getMonth() + 1}월{" "}
+                        {date.getDate()}일 ({dayOfWeek})
+                      </Body>
+
+                      <Chip
+                        color="green"
+                        round="s"
+                        style={{ padding: "6px 8px" }}
+                      >
+                        출석
+                      </Chip>
+                    </div>
+
+                    <div className={dateStatusContent}>
+                      <div className={statusItem}>
+                        <Body
+                          type="xsmall"
+                          weight={500}
+                          color={COLORS.gray[700]}
+                        >
+                          기록지
+                        </Body>
+
+                        <Chip
+                          color="blue"
+                          round="s"
+                          style={{ padding: "6px 8px" }}
+                        >
+                          작성 완료
+                        </Chip>
+
+                        <button
+                          className={confirmButton}
+                          onClick={() => handleViewCareSheet(date)}
+                          disabled={isLoading}
+                        >
+                          <Body
+                            type="xsmall"
+                            weight={500}
+                            color={COLORS.gray[600]}
+                          >
+                            확인 &gt;
+                          </Body>
+                        </button>
+                      </div>
+
+                      <div className={statusItem}>
+                        <Body
+                          type="xsmall"
+                          weight={500}
+                          color={COLORS.gray[700]}
+                        >
+                          리포트
+                        </Body>
+                        <Chip
+                          color="blue"
+                          round="s"
+                          style={{ padding: "6px 8px" }}
+                        >
+                          전송 완료
+                        </Chip>
+                        <button
+                          className={confirmButton}
+                          onClick={() => handleViewReport(date)}
+                          disabled={isLoading}
+                        >
+                          <Body
+                            type="xsmall"
+                            weight={500}
+                            color={COLORS.gray[600]}
+                          >
+                            확인 &gt;
+                          </Body>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* 오른쪽 영역 */}
+          <div className={historyModalContentRight}>
+            <div className={reportContainer}>
+              {!selectedDataType ? (
+                <div style={{ textAlign: "center", padding: "40px 0" }}>
+                  <Body
+                    type="medium"
+                    weight={600}
+                    color={COLORS.gray[900]}
+                    style={{ marginBottom: "16px" }}
+                  >
+                    날짜를 선택해주세요
+                  </Body>
+                </div>
+              ) : isLoading ? (
+                <div style={{ textAlign: "center", padding: "40px 0" }}>
+                  <Body
+                    type="medium"
+                    weight={600}
+                    color={COLORS.gray[900]}
+                    style={{ marginBottom: "16px" }}
+                  >
+                    데이터 로딩 중...
+                  </Body>
+                  <Body type="small" weight={400} color={COLORS.gray[600]}>
+                    잠시만 기다려주세요...
+                  </Body>
+                </div>
+              ) : selectedDataType === "report" ? (
+                <ReportDataView reportData={historyData} />
+              ) : (
+                <CareSheetDataView careSheetData={careSheetData} />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/daycan-front/apps/admin/src/pages/member/components/HistoryModal/index.ts
+++ b/daycan-front/apps/admin/src/pages/member/components/HistoryModal/index.ts
@@ -1,0 +1,9 @@
+/**
+ * HistoryModal 컴포넌트는 멤버 데이터 상세 페이지에서 사용되는 모달 컴포넌트입니다.
+ * 멤버 데이터 상세 페이지에서 기록지 및 리포트 내역을 통해 기록지(케어시트)나 리포트의 데이터를 확인할 수 있습니다.
+ * 각 데이터의 타입에 따라, CareSheetDataView, ReportDataView 컴포넌트를 사용합니다.
+ * CareSheetDataView 컴포넌트는 기록지(케어시트)의 데이터를 파싱해 보기 좋게 표시하며, 그 과정에서 CareSheetDataSummaryCard 컴포넌트를 사용합니다.
+ * 기록지 및 리포트 내역을 누를 시에 나오는 컴포넌트입니다!
+ * @author 홍규진
+ */
+export * from "./HistoryModal";

--- a/daycan-front/apps/admin/src/pages/member/components/HistoryModal/useHistoryModal.ts
+++ b/daycan-front/apps/admin/src/pages/member/components/HistoryModal/useHistoryModal.ts
@@ -1,0 +1,314 @@
+import { useState } from "react";
+
+//TODO: 임시 데이터 타입 정의(어차피 나중가서 API 연동 시 싸그리 다 제거 필요)
+export interface Entry {
+  key: string;
+  value: string;
+  warning: string;
+  additionalInfo: string;
+}
+
+export interface CardFooter {
+  score: number;
+  additionalMemo: string;
+}
+
+export interface ReportHistoryData {
+  totalScore: number;
+  changeAmount: number;
+  mealScore: number;
+  healthScore: number;
+  physicalScore: number;
+  cognitiveScore: number;
+  mealEntries: Entry[];
+  mealCardFooter: CardFooter;
+  healthEntries: Entry[];
+  healthCardFooter: CardFooter;
+  physicalEntries: Entry[];
+  physicalCardFooter: CardFooter;
+  cognitiveEntries: Entry[];
+  CognitiveCardFooter: CardFooter;
+}
+
+// ===== CareSheet 데이터 타입 정의 =====
+export interface CareSheetHistoryData {
+  id: number;
+  writerId: number;
+  recipientId: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  mobilityNumber: string;
+  physical: {
+    assistWashing: boolean;
+    assistMovement: boolean;
+    assistBathing: boolean;
+    bathingDurationMinutes: string;
+    bathingType: string;
+    breakfast: {
+      provided: boolean;
+      entry: {
+        mealType: string;
+        amount: string;
+      };
+      validProvidedEntry: boolean;
+    };
+    lunch: {
+      provided: boolean;
+      entry: {
+        mealType: string;
+        amount: string;
+      };
+      validProvidedEntry: boolean;
+    };
+    dinner: {
+      provided: boolean;
+      entry: {
+        mealType: string;
+        amount: string;
+      };
+      validProvidedEntry: boolean;
+    };
+    numberOfStool: number;
+    numberOfUrine: number;
+    comment: string;
+  };
+  cognitive: {
+    assistCognitiveCare: boolean;
+    assistCommunication: boolean;
+    comment: string;
+  };
+  healthCare: {
+    healthCare: boolean;
+    nursingCare: boolean;
+    emergencyService: boolean;
+    bloodPressure: {
+      systolic: number;
+      diastolic: number;
+    };
+    temperature: number;
+    comment: string;
+  };
+  recoveryProgram: {
+    motionTraining: boolean;
+    cognitiveProgram: boolean;
+    cognitiveEnhancement: boolean;
+    physicalTherapy: boolean;
+    programEntries: Array<{
+      type: string;
+      name: string;
+      score: string;
+    }>;
+    comment: string;
+  };
+}
+
+export const useHistoryModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [historyData, setHistoryData] = useState<ReportHistoryData | null>(
+    null
+  );
+  const [careSheetData, setCareSheetData] =
+    useState<CareSheetHistoryData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // ===== 데이터 조회 함수 =====
+  const fetchHistoryData = async (date: Date, memberId: string) => {
+    console.log("fetchHistoryData", date, memberId);
+    setIsLoading(true);
+    try {
+      // TODO: 실제 API 호출로 교체
+      // const response = await api.getHistoryData(date);
+      // setHistoryData(response.data);
+
+      // 임시 데이터 (실제 연동 시 제거)
+      const mockReportHistoryData: ReportHistoryData = {
+        totalScore: 85,
+        changeAmount: 10,
+        mealScore: 15,
+        healthScore: 15,
+        physicalScore: 15,
+        cognitiveScore: 15,
+        mealEntries: [
+          {
+            key: "아침",
+            value: "오늘은 아침을 했어요!",
+            warning: "반찬 투정을 하셨어요",
+            additionalInfo: "식사량: 80%",
+          },
+          {
+            key: "점심",
+            value: "오늘은 점심을 했어요!",
+            warning: "",
+            additionalInfo: "식사량: 90%",
+          },
+          {
+            key: "저녁",
+            value: "오늘은 저녁을 했어요!",
+            warning: "",
+            additionalInfo: "식사량: 85%",
+          },
+        ],
+        mealCardFooter: {
+          score: 15,
+          additionalMemo: "오늘 식사를 완료했어요",
+        },
+        healthEntries: [
+          {
+            key: "혈압",
+            value: "120/80",
+            warning: "",
+            additionalInfo: "정상 범위",
+          },
+          {
+            key: "체온",
+            value: "36.5℃",
+            warning: "",
+            additionalInfo: "정상 체온",
+          },
+        ],
+        healthCardFooter: {
+          score: 15,
+          additionalMemo: "건강 상태 양호",
+        },
+        physicalEntries: [
+          {
+            key: "게이트 볼",
+            value: "게이트 볼을 통해서, 몸과 마음을 단련시켰어요.",
+            warning: "",
+            additionalInfo: "활동 시간: 30분",
+          },
+        ],
+        physicalCardFooter: {
+          score: 15,
+          additionalMemo: "신체 활동 완료",
+        },
+        cognitiveEntries: [
+          {
+            key: "노래부르기",
+            value: "노래부르기 활동을 통해서, 몸과 마음을 단련시켰어요.",
+            warning: "",
+            additionalInfo: "참여도: 높음",
+          },
+        ],
+        CognitiveCardFooter: {
+          score: 15,
+          additionalMemo: "인지 활동 완료",
+        },
+      };
+
+      setHistoryData(mockReportHistoryData);
+    } catch (error) {
+      console.error("데이터 조회 실패:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // ===== CareSheet 데이터 조회 함수 =====
+  const fetchCareSheetData = async (date: Date, memberId: string) => {
+    console.log("fetchCareSheetData", date, memberId);
+    setIsLoading(true);
+    console.log("fetchCareSheetData", date);
+    try {
+      // TODO: 실제 API 호출로 교체
+      // const response = await api.getCareSheetData(date);
+      // setCareSheetData(response.data);
+
+      // 임시 데이터 (실제 연동 시 제거)
+      const mockCareSheetHistoryData: CareSheetHistoryData = {
+        id: 10,
+        writerId: 1,
+        recipientId: "RP123456",
+        date: "2025-08-01",
+        startTime: "09:00",
+        endTime: "17:00",
+        mobilityNumber: "123가4567",
+        physical: {
+          assistWashing: true,
+          assistMovement: true,
+          assistBathing: true,
+          bathingDurationMinutes: "30분",
+          bathingType: "샤워",
+          breakfast: {
+            provided: true,
+            entry: {
+              mealType: "REGULAR",
+              amount: "FULL",
+            },
+            validProvidedEntry: true,
+          },
+          lunch: {
+            provided: true,
+            entry: {
+              mealType: "REGULAR",
+              amount: "FULL",
+            },
+            validProvidedEntry: true,
+          },
+          dinner: {
+            provided: true,
+            entry: {
+              mealType: "REGULAR",
+              amount: "FULL",
+            },
+            validProvidedEntry: true,
+          },
+          numberOfStool: 1,
+          numberOfUrine: 3,
+          comment: "보행 시 통증 호소",
+        },
+        cognitive: {
+          assistCognitiveCare: true,
+          assistCommunication: true,
+          comment: "대화 시 약간의 혼동 보임",
+        },
+        healthCare: {
+          healthCare: true,
+          nursingCare: false,
+          emergencyService: false,
+          bloodPressure: {
+            systolic: 0,
+            diastolic: 0,
+          },
+          temperature: 36.5,
+          comment: "정상 범위 유지",
+        },
+        recoveryProgram: {
+          motionTraining: true,
+          cognitiveProgram: true,
+          cognitiveEnhancement: false,
+          physicalTherapy: true,
+          programEntries: [
+            {
+              type: "PHYSICAL",
+              name: "숫자 맞추기 게임",
+              score: "HIGH",
+            },
+          ],
+          comment: "프로그램에 적극적으로 참여",
+        },
+      };
+
+      setCareSheetData(mockCareSheetHistoryData);
+    } catch (error) {
+      console.error("CareSheet 데이터 조회 실패:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const openModal = () => setIsOpen(true);
+  const closeModal = () => setIsOpen(false);
+
+  return {
+    isOpen,
+    openModal,
+    closeModal,
+    historyData,
+    careSheetData,
+    isLoading,
+    fetchHistoryData,
+    fetchCareSheetData,
+  };
+};

--- a/daycan-front/apps/admin/src/pages/member/components/MemberDataItemDetail/MemberDataItemDetail.tsx
+++ b/daycan-front/apps/admin/src/pages/member/components/MemberDataItemDetail/MemberDataItemDetail.tsx
@@ -8,6 +8,8 @@ import {
   memberDataItemDetailBottomButton,
   editButton,
 } from "./MemberDataItemDetail.css";
+import { useState } from "react";
+import { HistoryModal } from "../HistoryModal/HistoryModal";
 
 interface MemberDataItemDetailProps {
   detailCard?: React.ReactNode;
@@ -31,7 +33,7 @@ export const MemberDataItemDetail = ({
   const handleDeleteClick = () => {
     onDeleteButtonClick(memberId);
   };
-
+  const [isHistoryModalOpen, setIsHistoryModalOpen] = useState(false);
   return (
     <div className={memberDataItemDetailContainer}>
       <div className={memberDataItemDetailContent}>
@@ -42,6 +44,7 @@ export const MemberDataItemDetail = ({
             <Button
               size="fullWidth"
               style={{ backgroundColor: COLORS.gray[600], color: COLORS.white }}
+              onClick={() => setIsHistoryModalOpen(true)}
             >
               기록지 및 리포트 내역
               <Icon
@@ -70,6 +73,11 @@ export const MemberDataItemDetail = ({
           </div>
         </div>
       </div>
+      <HistoryModal
+        memberId={memberId}
+        isOpen={isHistoryModalOpen}
+        onClose={() => setIsHistoryModalOpen(false)}
+      />
     </div>
   );
 };

--- a/daycan-front/apps/admin/src/pages/member/components/MemberDeleteConfirmModal/MemberDeleteConfirmModal.css.ts
+++ b/daycan-front/apps/admin/src/pages/member/components/MemberDeleteConfirmModal/MemberDeleteConfirmModal.css.ts
@@ -2,7 +2,8 @@ import { style } from "@vanilla-extract/css";
 
 export const memberDeleteConfirmModalContainer = style({
   width: "700px",
-  height: "140px",
+  padding: "24px",
+  height: "181px",
   display: "flex",
   flexDirection: "column",
   justifyContent: "space-between",

--- a/daycan-front/apps/admin/src/pages/member/components/MemberEditAuthModal/MemberEditAuthModal.css.ts
+++ b/daycan-front/apps/admin/src/pages/member/components/MemberEditAuthModal/MemberEditAuthModal.css.ts
@@ -2,6 +2,7 @@ import { style } from "@vanilla-extract/css";
 
 export const memberEditAuthModalContent = style({
   width: "700px",
+  padding: "24px",
   height: "100%",
 });
 

--- a/daycan-front/apps/admin/src/router/routes.tsx
+++ b/daycan-front/apps/admin/src/router/routes.tsx
@@ -24,6 +24,16 @@ export type TRoutes = {
 
 export const routes: TRoutes[] = [
   {
+    path: "/",
+    layout: <MainLayout />,
+    children: [
+      {
+        path: "",
+        element: <CareSheetPage />,
+      },
+    ],
+  },
+  {
     path: "/member",
     layout: <MainLayout />,
     children: [
@@ -42,10 +52,6 @@ export const routes: TRoutes[] = [
       {
         path: "edit/:memberId",
         element: <MemberRegisterPage mode="edit" />,
-      },
-      {
-        path: "care-sheet",
-        element: <CareSheetPage />,
       },
     ],
   },

--- a/daycan-front/apps/client/src/pages/daily-report/components/CardLayout/CardLayout.tsx
+++ b/daycan-front/apps/client/src/pages/daily-report/components/CardLayout/CardLayout.tsx
@@ -56,6 +56,7 @@ export const CardLayout = ({
           width={32}
           height={32}
           color={COLORS.blue[500]}
+          stroke={COLORS.white}
         />
         <Body type="large" weight={600}>
           오늘의

--- a/daycan-front/apps/client/src/pages/daily-report/components/HealthIndexCard/HealthIndexCard.tsx
+++ b/daycan-front/apps/client/src/pages/daily-report/components/HealthIndexCard/HealthIndexCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { SemiCircularGaugeChart, UpDownIcon } from "@/components";
+import { SemiCircularGaugeChart, UpDownIcon } from "../../../../components";
 import { Body, COLORS, Icon } from "@daycan/ui";
 import {
   container,

--- a/daycan-front/apps/client/src/pages/login/LoginPage.tsx
+++ b/daycan-front/apps/client/src/pages/login/LoginPage.tsx
@@ -89,6 +89,7 @@ export const LoginPage = () => {
                 width={16}
                 height={16}
                 color={COLORS.gray[900]}
+                stroke={COLORS.white}
               />
             ) : (
               <Icon

--- a/daycan-front/apps/client/src/pages/login/components/ForgotCredentialsModal/ForgotCredentialsModal.css.ts
+++ b/daycan-front/apps/client/src/pages/login/components/ForgotCredentialsModal/ForgotCredentialsModal.css.ts
@@ -1,6 +1,7 @@
 import { style } from "@vanilla-extract/css";
 
 export const modalContent = style({
+  padding: "24px",
   display: "flex",
   flexDirection: "column",
   gap: "16px",

--- a/daycan-front/apps/client/src/pages/main/components/InfoModal/InfoModal.css.ts
+++ b/daycan-front/apps/client/src/pages/main/components/InfoModal/InfoModal.css.ts
@@ -1,6 +1,13 @@
 import { COLORS } from "@daycan/ui";
 import { style } from "@vanilla-extract/css";
 
+export const infoModalContent = style({
+  padding: "24px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "16px",
+});
+
 export const pointCalculateContainer = style({
   display: "flex",
   flexDirection: "row",

--- a/daycan-front/apps/client/src/pages/main/components/InfoModal/InfoModal.tsx
+++ b/daycan-front/apps/client/src/pages/main/components/InfoModal/InfoModal.tsx
@@ -1,5 +1,9 @@
 import { Body, Button, Chip, COLORS, Modal } from "@daycan/ui";
-import { pointCalculateContainer, pointCalculateItem } from "./InfoModal.css";
+import {
+  infoModalContent,
+  pointCalculateContainer,
+  pointCalculateItem,
+} from "./InfoModal.css";
 interface InfoModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -7,63 +11,66 @@ interface InfoModalProps {
 export const InfoModal = ({ isOpen, onClose }: InfoModalProps) => {
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      <Body type="medium" weight={600} color={COLORS.gray[900]}>
-        이번 주 평균 건강 지수란?
-      </Body>
-      <Body
-        type="small"
-        weight={400}
-        style={{ color: COLORS.gray[600], whiteSpace: "pre-line" }}
-      >
-        {`이번 주 건강 지수의 평균값을 보여줘요.\n\n월요일에는 월요일의 건강 지수만 표시되고, 금요일에는 월요일부터 금요일까지의 건강 지수를 모두 평균내어 표시돼요.`}
-      </Body>
-      <div className={pointCalculateContainer}>
-        <div className={pointCalculateItem}>
-          <Body type="xsmall" weight={400} color={COLORS.gray[600]}>
-            80점 이상
-          </Body>
-          <Chip
-            style={{
-              backgroundColor: COLORS.green[200],
-              padding: "8px 4px",
-              color: COLORS.green[500],
-            }}
-          >
-            안정
-          </Chip>
+      <div className={infoModalContent}>
+        <Body type="medium" weight={600} color={COLORS.gray[900]}>
+          이번 주 평균 건강 지수란?
+        </Body>
+        <Body
+          type="small"
+          weight={400}
+          style={{ color: COLORS.gray[600], whiteSpace: "pre-line" }}
+        >
+          {`이번 주 건강 지수의 평균값을 보여줘요.\n\n월요일에는 월요일의 건강 지수만 표시되고, 금요일에는 월요일부터 금요일까지의 건강 지수를 모두 평균내어 표시돼요.`}
+        </Body>
+        <div className={pointCalculateContainer}>
+          <div className={pointCalculateItem}>
+            <Body type="xsmall" weight={400} color={COLORS.gray[600]}>
+              80점 이상
+            </Body>
+            <Chip
+              style={{
+                backgroundColor: COLORS.green[200],
+                padding: "8px 4px",
+                color: COLORS.green[500],
+              }}
+            >
+              안정
+            </Chip>
+          </div>
+          <div className={pointCalculateItem}>
+            <Body type="xsmall" weight={400} color={COLORS.gray[600]}>
+              50~79점
+            </Body>
+            <Chip
+              style={{
+                backgroundColor: COLORS.yellow[200],
+                padding: "8px 4px",
+                color: COLORS.yellow[500],
+              }}
+            >
+              보통
+            </Chip>
+          </div>
+          <div className={pointCalculateItem}>
+            <Body type="xsmall" weight={400} color={COLORS.gray[600]}>
+              49점 이하
+            </Body>
+            <Chip
+              style={{
+                backgroundColor: COLORS.red[200],
+                padding: "8px 4px",
+                color: COLORS.red[500],
+              }}
+            >
+              주의
+            </Chip>
+          </div>
         </div>
-        <div className={pointCalculateItem}>
-          <Body type="xsmall" weight={400} color={COLORS.gray[600]}>
-            50~79점
-          </Body>
-          <Chip
-            style={{
-              backgroundColor: COLORS.yellow[200],
-              padding: "8px 4px",
-              color: COLORS.yellow[500],
-            }}
-          >
-            보통
-          </Chip>
-        </div>
-        <div className={pointCalculateItem}>
-          <Body type="xsmall" weight={400} color={COLORS.gray[600]}>
-            49점 이하
-          </Body>
-          <Chip
-            style={{
-              backgroundColor: COLORS.red[200],
-              padding: "8px 4px",
-              color: COLORS.red[500],
-            }}
-          >
-            주의
-          </Chip>
-        </div>
+
+        <Button size="fullWidth" variant="primary" onClick={onClose}>
+          확인
+        </Button>
       </div>
-      <Button size="fullWidth" variant="primary" onClick={onClose}>
-        확인
-      </Button>
     </Modal>
   );
 };

--- a/daycan-front/packages/ui/src/components/Modal/Modal.css.ts
+++ b/daycan-front/packages/ui/src/components/Modal/Modal.css.ts
@@ -28,7 +28,6 @@ export const contentStyle = style({
   display: "flex",
   flexDirection: "column",
   gap: "8px",
-  padding: "24px",
   borderRadius: "8px",
   boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
   minWidth: "300px",

--- a/daycan-front/packages/ui/src/components/Modal/Modal.tsx
+++ b/daycan-front/packages/ui/src/components/Modal/Modal.tsx
@@ -9,17 +9,25 @@ export type ModalProps = {
   isOpen: boolean;
   onClose: () => void;
   children: ReactNode;
+  container?: HTMLElement; // 포탈할 컨테이너 요소
 };
 
-export const Modal = ({ isOpen, onClose, children }: ModalProps) => {
+export const Modal = ({
+  isOpen,
+  onClose,
+  children,
+  container = document.getElementById("modal-root") as HTMLElement,
+}: ModalProps) => {
   return (
     <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <Dialog.Overlay className={overlayStyle} />
-      <Dialog.DialogTitle className={hidden}>title</Dialog.DialogTitle>
-      <Dialog.DialogDescription className={hidden}>
-        hiddenDescription
-      </Dialog.DialogDescription>
-      <Dialog.Content className={contentStyle}>{children}</Dialog.Content>
+      <Dialog.Portal container={container}>
+        <Dialog.Overlay className={overlayStyle} />
+        <Dialog.DialogTitle className={hidden}>title</Dialog.DialogTitle>
+        <Dialog.DialogDescription className={hidden}>
+          hiddenDescription
+        </Dialog.DialogDescription>
+        <Dialog.Content className={contentStyle}>{children}</Dialog.Content>
+      </Dialog.Portal>
     </Dialog.Root>
   );
 };


### PR DESCRIPTION
## 관련 이슈

- Resolves : #116 (전송에 필요한 내부 컴포넌트들 구현입니다!)

## 작업 사항
### 작업 영상 
https://github.com/user-attachments/assets/75eeb4d9-4c17-4543-986d-69b995631f01

- 리포트 전송 과정에 필요한 모달을 구현합니다.
- API 흐름은 다음과 같습니다.
1. API : YYYY-MM 요청시 좌측 리스트 제공(일자, careSheetId) 
2. /admin/care-sheet/{date}/{recipientId} - 기록지 단건 조회 
3. /admin/care-report/{date}/{recipientId} - 리포트 단건 조회 

### 기록지 단건 조회 및 리포트 단건 조회 컴포넌트 구현

|CareSheetDataSummaryCard|CareSheetDataView|ReportDataView|
|---|---|---|
|<img width="441" height="202" alt="image" src="https://github.com/user-attachments/assets/3f571a34-7973-4387-93c7-7250f2486c09" />|<img width="504" height="470" alt="image" src="https://github.com/user-attachments/assets/81f31884-300f-4471-8079-d2e50b3978db" />|<img width="500" height="473" alt="image" src="https://github.com/user-attachments/assets/02b0e60b-4bad-4a3e-8012-50b183ee4503" />|

### 기존의 모달 시스템 padding 삭제 
- 여태 모든 모달들은 내부의 padding 이 24px 이 공통으로 있었으나... 유일한 PR 영상 속 모달만 padding 이 없어, 시스템에서의 padding 을 제거하고 모든 Modal 의 container 에다가 padding 을 넣게 되었습니다.

### 마찬가지로 Icon(circleCheck) 내 Stroke 요소 추가로 인한 수정 
- 위와 동일합니다!
- 다음과 같은 작업을 아마, ChevronLeft, ChevronRight 에 적용해야할 것 같습니다..!

## 참고 사항
- 최초의 디자인은 기존의 Funnel 내부 Step 의 컴포넌트를 재활용해 디자인 해주셨는데, 이는 Funnel 내부 State와 결합도가 높기도 하였고, 수정이 아닌 보는 데에는 불편하다는 이유로 정책과 함께 디자인을 수정하였습니다...!
