### PR TITLE
Feature/fe/#145 (PC + 모바일) 센터 종사자 반응형 로그인 페이지 제작

### DIFF
--- a/daycan-front/apps/admin/src/components/Footer/Footer.css.ts
+++ b/daycan-front/apps/admin/src/components/Footer/Footer.css.ts
@@ -15,6 +15,13 @@ export const footerContent = style({
   width: "775px",
   flexDirection: "column",
   gap: "12px",
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      width: "90%",
+      minWidth: "320px",
+    },
+  },
 });
 
 export const footerLogo = style({
@@ -42,6 +49,12 @@ export const footerDivider = style({
   width: "1px",
   height: "6px",
   backgroundColor: COLORS.gray[300],
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      display: "none",
+    },
+  },
 });
 
 export const footerLogoLinks = style({
@@ -55,4 +68,12 @@ export const footerInfo = style({
   display: "flex",
   flexDirection: "row",
   gap: "44px",
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      flexDirection: "column",
+      gap: "16px",
+      alignItems: "flex-start",
+    },
+  },
 });

--- a/daycan-front/apps/admin/src/layout/login/LoginLayout.css.ts
+++ b/daycan-front/apps/admin/src/layout/login/LoginLayout.css.ts
@@ -10,6 +10,14 @@ export const container = style({
   alignItems: "center",
   justifyContent: "center",
   boxSizing: "border-box",
+  "@media": {
+    "screen and (max-width: 768px)": {
+      width: "100%",
+      minHeight: "600px",
+      minWidth: "320px",
+      backgroundColor: COLORS.white,
+    },
+  },
 });
 
 export const section = style({
@@ -22,4 +30,13 @@ export const section = style({
   minHeight: "726px",
   marginBottom: "20px",
   flexShrink: 0,
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      width: "100%",
+      minHeight: "600px",
+      minWidth: "320px",
+      backgroundColor: COLORS.white,
+    },
+  },
 });

--- a/daycan-front/apps/admin/src/pages/login/LoginPage.css.ts
+++ b/daycan-front/apps/admin/src/pages/login/LoginPage.css.ts
@@ -10,6 +10,15 @@ export const loginContainer = style({
   justifyContent: "center",
 
   background: COLORS.gray[50],
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      width: "100%",
+      minHeight: "600px",
+      minWidth: "320px",
+      backgroundColor: COLORS.white,
+    },
+  },
 });
 
 export const loginCard = style({
@@ -20,6 +29,15 @@ export const loginCard = style({
   borderRadius: "20px",
   width: "718px",
   height: "726px",
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      flex: "1 1 auto",
+      width: "100%",
+      minHeight: "auto",
+      backgroundColor: COLORS.white,
+    },
+  },
 });
 
 export const loginHeader = style({
@@ -29,6 +47,12 @@ export const loginHeader = style({
   alignItems: "center",
   textAlign: "center",
   gap: "16px",
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      marginTop: "185px",
+    },
+  },
 });
 
 export const headerContent = style({
@@ -45,6 +69,15 @@ export const form = style({
   marginTop: "48px",
   gap: "8px",
   width: "532px",
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      width: "90%",
+      minWidth: "320px",
+      margin: "0px",
+      marginTop: "48px",
+    },
+  },
 });
 
 export const inputGroup = style({
@@ -85,6 +118,22 @@ export const checkContainer = style({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
-  margin: "12px 93px 0px 93px",
+  marginTop: "12px",
   width: "532px",
+
+  "@media": {
+    "screen and (max-width: 768px)": {
+      width: "90%",
+      minWidth: "320px",
+    },
+  },
+});
+
+export const subDescription = style({
+  color: COLORS.gray[800],
+  "@media": {
+    "screen and (max-width: 768px)": {
+      display: "none",
+    },
+  },
 });

--- a/daycan-front/apps/admin/src/pages/login/LoginPage.tsx
+++ b/daycan-front/apps/admin/src/pages/login/LoginPage.tsx
@@ -9,6 +9,7 @@ import {
   loginHeader,
   checkContainer,
   headerContent,
+  subDescription,
 } from "./LoginPage.css";
 import { useAdminLoginHook } from "./hooks";
 import { ForgotCredentialsModal } from "./components/ForgotCredentialsModal";
@@ -43,7 +44,7 @@ export const LoginPage = () => {
             >
               센터종사자 로그인
             </Heading>
-            <Body type="small" weight={400} style={{ color: COLORS.gray[800] }}>
+            <Body type="small" weight={400} className={subDescription}>
               어떻게 치매까지 사랑하겠어, 엄마를 사랑하는 거지...
             </Body>
           </div>
@@ -55,7 +56,7 @@ export const LoginPage = () => {
             <Input
               type="text"
               variant="grayLight"
-              inputSize="pcTextFieldLarge"
+              inputSize="full"
               placeholder="아이디"
               color="grayLight"
               value={email}
@@ -67,7 +68,7 @@ export const LoginPage = () => {
             <Input
               type="password"
               variant="grayLight"
-              inputSize="pcTextFieldLarge"
+              inputSize="full"
               placeholder="비밀번호"
               color="grayLight"
               value={password}


### PR DESCRIPTION
## 관련 이슈
- Resolves : #145

 
 ## 작업 사항

https://github.com/user-attachments/assets/71c017fc-dfb4-4a04-8400-2eeb4a19da64





- 768px을 기준으로 media 스타일을 적용하였습니다.
- Input 컴포넌트와 여러 컨테이너들을 width 100%로 설정하여 반응형에 잘 동작 할 수 있게 하였으며 Input 컴포넌트와 버튼을 가지고 있는 form태그는 width:90%로 하여 약간의 빈공간을 만들었습니다.
- 320px보다 작아지면 화면이 가려질 수 있도록 minWidth를 320px로 지정하였습니다.
- Footer를 스크롤로 내릴 수 있게 화면 밑으로 가렸습니다. 그 이유로는 디자인상 로그인화면보다 Footer에 집중이 되어 좋아 보이지 않았고 로그인 페이지에 로그인만 있는게 더 괜찮아 보였습니다.

## 참고 사항

