### PR TITLE
Refactor/fe/#186 funnel atom prefill logic

### DIFF
--- a/daycan-front/apps/admin/src/pages/care-sheet-today/TodayCareSheetPage.css.ts
+++ b/daycan-front/apps/admin/src/pages/care-sheet-today/TodayCareSheetPage.css.ts
@@ -14,6 +14,10 @@ export const todayCareSheetPageContentContainer = style({
   flex: 1,
   display: "flex",
   flexDirection: "column",
+  maxHeight: "100dvh",
+  overflowY: "auto",
+  paddingBottom: 100,
+  boxSizing: "border-box",
   gap: 10,
   marginTop: 25,
 });

--- a/daycan-front/apps/admin/src/pages/care-sheet-today/TodayCareSheetPage.tsx
+++ b/daycan-front/apps/admin/src/pages/care-sheet-today/TodayCareSheetPage.tsx
@@ -3,23 +3,24 @@ import {
   todayCareSheetPageContainer,
   todayCareSheetPageContentContainer,
 } from "./TodayCareSheetPage.css";
-import { useAtomValue } from "jotai";
-import { homeFunnelDataAtom } from "../care-sheet/funnels/home-funnel/atoms/homeAtom";
 import { CareSheetListItem } from "./components/CareSheetListItem";
 import { MobileEmptyState } from "@/components/MobileEmptyState";
 import { emptyCareSheetList } from "./constants/dummy";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { StepButtons } from "../care-sheet/components/StepButtons";
 import { TODAY_DATE } from "@/utils/dateFormatter";
 import { useGetCareSheetListQuery } from "@/services/careSheet/useCareSheetQuery";
 
 export const TodayCareSheetPage = () => {
   const navigate = useNavigate();
-  const homeFunnelData = useAtomValue(homeFunnelDataAtom);
+  const { writerId } = useParams();
+
+  // URL 파라미터에서 writerId 가져오기
+  console.log("URL에서 가져온 writerId:", writerId);
 
   const { data: careSheetList } = useGetCareSheetListQuery(
     TODAY_DATE,
-    homeFunnelData?.writerId
+    writerId ? parseInt(writerId) : undefined
   );
 
   // 개발용 더미 데이터 사용 (실제 데이터가 없을 때)

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/diagnosis-funnel/DiagnosisFunnelStepContainer.tsx
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/diagnosis-funnel/DiagnosisFunnelStepContainer.tsx
@@ -2,7 +2,7 @@ import { FunnelProvider, FunnelStep, type FunnelState } from "@daycan/hooks";
 import { Step0, Step1, Step2, Step3, Step4, Step5 } from "./steps";
 import { diagnosisFunnelSteps } from "../../constants/steps";
 import { useAtomValue, useSetAtom } from "jotai";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { diagnosisFunnelDataAtom } from "./atoms/diagnosisAtom";
 import { convertFunnelStateToDiagnosisFunnelData } from "./utils/parsingData";
 import { infoFunnelDataAtom } from "../info-funnel/atoms/infoAtom";
@@ -12,41 +12,42 @@ import {
   MEAL_AMOUNT_CODE_TO_LABEL,
   MEAL_TYPE_CODE_TO_LABEL,
 } from "./constants/diagnosis";
-import { getStoredValue } from "../utils/storage";
 import { useWriteCareSheetMutation } from "@/services/careSheet/useCareSheetMutation";
-import { combineFunnelData } from "../utils/atomUtil";
-import { homeFunnelDataAtom } from "../home-funnel/atoms/homeAtom";
-import type { TCareSheetWriteRequest } from "@/services/careSheet/types";
 import { useToast } from "@daycan/ui";
-import { resetAllFunnelsAtom } from "../molecule/finalMolecule";
+import {
+  combinedCareSheetAtom,
+  resetAllFunnelsAtom,
+} from "../molecule/finalMolecule";
+import { validateCareSheetData } from "../utils/atomUtil";
+import type { TCareSheetWriteRequest } from "@/services/careSheet/types";
+import { getStoredValue } from "../utils/storage";
 
 export const DiagnosisFunnelStepContainer = () => {
   const navigate = useNavigate();
-  const setDiagnosisData = useSetAtom(diagnosisFunnelDataAtom);
-  const homeData = useAtomValue(homeFunnelDataAtom);
   const infoData = useAtomValue(infoFunnelDataAtom);
+
+  const setDiagnosisData = useSetAtom(diagnosisFunnelDataAtom);
   const diagnosisData = useAtomValue(diagnosisFunnelDataAtom);
+
   const { showToast } = useToast();
   const resetAllFunnels = useSetAtom(resetAllFunnelsAtom);
+  const writeCareSheetRequest = useAtomValue(combinedCareSheetAtom);
+
   const writeCareSheetMutation = useWriteCareSheetMutation();
+
   // info 퍼널 데이터가 없으면 info 퍼널로 이동 (atom 초기 null hydration 대비 로컬스토리지도 확인)
-  useEffect(() => {
+  useMemo(() => {
     const stored = getStoredValue("careSheet:infoFunnel");
     if (stored === null) {
-      navigate("/care-sheet/new/info", { replace: true });
+      navigate("/care-sheet/new/info");
     }
-  }, [infoData]);
+  }, [infoData, navigate]);
 
   const handleComplete = (funnelState: FunnelState) => {
     const diagnosisData = convertFunnelStateToDiagnosisFunnelData(funnelState);
     setDiagnosisData(diagnosisData);
 
     // 모든 퍼널 데이터를 합쳐서 제출 요청 생성
-    const writeCareSheetRequest = combineFunnelData(
-      homeData,
-      infoData,
-      diagnosisData
-    ) as TCareSheetWriteRequest;
 
     // 제출 요청이 없으면 종료
     if (!writeCareSheetRequest) {
@@ -61,99 +62,204 @@ export const DiagnosisFunnelStepContainer = () => {
       return;
     }
 
+    // 타입 체크 및 에러 처리
+    const validationResult = validateCareSheetData(writeCareSheetRequest);
+    if (!validationResult.isValid) {
+      showToast({
+        data: {
+          message: validationResult.message,
+          type: "error",
+          variant: "mobile",
+        },
+        autoClose: 1000,
+      });
+    } else {
+      showToast({
+        data: {
+          message: validationResult.message,
+          type: "error",
+          variant: "mobile",
+        },
+        autoClose: 1000,
+      });
+    }
+
     // 제출 요청 전송
-    writeCareSheetMutation.mutate(writeCareSheetRequest, {
-      onSuccess: () => {
-        resetAllFunnels(); // 퍼널 상태 초기화
+    writeCareSheetMutation.mutate(
+      writeCareSheetRequest as TCareSheetWriteRequest,
+      {
+        onSuccess: () => {
+          resetAllFunnels(); // 퍼널 상태 초기화
 
-        // 토스트 메시지 표시
-        showToast({
-          data: {
-            message: "기록지 작성이 완료되었습니다.",
-            type: "success",
-            variant: "pc",
-          },
-          autoClose: 1500,
-          hideProgressBar: true,
-        });
+          // 토스트 메시지 표시
+          showToast({
+            data: {
+              message: "기록지 작성이 완료되었습니다.",
+              type: "success",
+              variant: "pc",
+            },
+            autoClose: 1500,
+          });
 
-        // photo-funnel로 이동
-        navigate("/care-sheet/new/");
-      },
-      onError: (error) => {
-        // 에러 발생 시 토스트 메시지 표시
-        showToast({
-          data: {
-            message: "기록지 작성 중 오류가 발생했습니다.",
-            type: "error",
-            variant: "pc",
-          },
-          autoClose: 1000,
-        });
-        console.error(error);
-      },
-    });
+          // photo-funnel로 이동
+          navigate("/care-sheet/new/");
+        },
+        onError: (error) => {
+          // 에러 발생 시 토스트 메시지 표시
+          showToast({
+            data: {
+              message: "기록지 작성 중 오류가 발생했습니다.",
+              type: "error",
+              variant: "pc",
+            },
+            autoClose: 1000,
+          });
+          console.error(error);
+        },
+      }
+    );
   };
 
   // photo-funnel로부터 채워진 diagnosis atom을 funnelState로 프리필하고 바로 Step4로 진입
   const initialState: FunnelState | undefined = useMemo(() => {
-    const d: DiagnosisFunnelData | null = diagnosisData;
-    if (!d) return undefined;
-    return {
-      STEP_0: {
-        isWashHelperChecked: d.physical.assistWashing,
-        isMoveHelperChecked: d.physical.assistMovement,
-        isBathHelperChecked: d.physical.assistBathing,
-        isBreakfastChecked: d.physical.breakfast.provided,
-        breakfastType:
-          MEAL_TYPE_CODE_TO_LABEL[d.physical.breakfast.entry.mealType || ""] ||
-          d.physical.breakfast.entry.mealType,
-        breakfastAmount:
-          MEAL_AMOUNT_CODE_TO_LABEL[d.physical.breakfast.entry.amount || ""] ||
-          d.physical.breakfast.entry.amount,
-        isLunchChecked: d.physical.lunch.provided,
-        lunchType:
-          MEAL_TYPE_CODE_TO_LABEL[d.physical.lunch.entry.mealType || ""] ||
-          d.physical.lunch.entry.mealType,
-        lunchAmount:
-          MEAL_AMOUNT_CODE_TO_LABEL[d.physical.lunch.entry.amount || ""] ||
-          d.physical.lunch.entry.amount,
-        isDinnerChecked: d.physical.dinner.provided,
-        dinnerType:
-          MEAL_TYPE_CODE_TO_LABEL[d.physical.dinner.entry.mealType || ""] ||
-          d.physical.dinner.entry.mealType,
-        dinnerAmount:
-          MEAL_AMOUNT_CODE_TO_LABEL[d.physical.dinner.entry.amount || ""] ||
-          d.physical.dinner.entry.amount,
-        urineCount: d.physical.numberOfUrine,
-        stoolCount: d.physical.numberOfStool,
-        physicalActivity: d.physical.comment,
-      },
-      STEP_1: {
-        isCognitiveHelperChecked: d.cognitive.assistCognitiveCare,
-        isCommunicationHelperChecked: d.cognitive.assistCommunication,
-        physicalActivity: d.cognitive.comment,
-      },
-      STEP_2: {
-        isHealthManagementChecked: d.healthCare.healthCare,
-        isNursingManagementChecked: d.healthCare.nursingCare,
-        isEmergencyServiceChecked: d.healthCare.emergencyService,
-        systolic: d.healthCare.bloodPressure.systolic,
-        diastolic: d.healthCare.bloodPressure.diastolic,
-        temperature: d.healthCare.temperature.temperature,
-        healthManageSpecialNote: d.healthCare.comment,
-      },
-      STEP_3: {
-        isTrainingChecked: d.recoveryProgram.motionTraining,
-        isCognitiveActivityTrainingChecked: d.recoveryProgram.cognitiveProgram,
-        isCognitiveFunctionEnhancementTrainingChecked:
-          d.recoveryProgram.cognitiveEnhancement,
-        isPhysicalTherapyChecked: d.recoveryProgram.physicalTherapy,
-        trainingSpecialNote: d.recoveryProgram.comment,
-        programEntries: d.recoveryProgram.programEntries,
-        signatureUrl: d.signatureUrl,
-      },
-    } as FunnelState;
+    // atom에서 데이터 확인 - 데이터가 있고 physical이 존재하는 경우만
+    if (diagnosisData && diagnosisData.physical) {
+      return {
+        STEP_0: {
+          isWashHelperChecked: diagnosisData.physical.assistWashing,
+          isMoveHelperChecked: diagnosisData.physical.assistMovement,
+          isBathHelperChecked: diagnosisData.physical.assistBathing,
+          isBreakfastChecked: diagnosisData.physical.breakfast.provided,
+          breakfastType:
+            MEAL_TYPE_CODE_TO_LABEL[
+              diagnosisData.physical.breakfast.entry.mealType || ""
+            ] || diagnosisData.physical.breakfast.entry.mealType,
+          breakfastAmount:
+            MEAL_AMOUNT_CODE_TO_LABEL[
+              diagnosisData.physical.breakfast.entry.amount || ""
+            ] || diagnosisData.physical.breakfast.entry.amount,
+          isLunchChecked: diagnosisData.physical.lunch.provided,
+          lunchType:
+            MEAL_TYPE_CODE_TO_LABEL[
+              diagnosisData.physical.lunch.entry.mealType || ""
+            ] || diagnosisData.physical.lunch.entry.mealType,
+          lunchAmount:
+            MEAL_AMOUNT_CODE_TO_LABEL[
+              diagnosisData.physical.lunch.entry.amount || ""
+            ] || diagnosisData.physical.lunch.entry.amount,
+          isDinnerChecked: diagnosisData.physical.dinner.provided,
+          dinnerType:
+            MEAL_TYPE_CODE_TO_LABEL[
+              diagnosisData.physical.dinner.entry.mealType || ""
+            ] || diagnosisData.physical.dinner.entry.mealType,
+          dinnerAmount:
+            MEAL_AMOUNT_CODE_TO_LABEL[
+              diagnosisData.physical.dinner.entry.amount || ""
+            ] || diagnosisData.physical.dinner.entry.amount,
+          urineCount: diagnosisData.physical.numberOfUrine,
+          stoolCount: diagnosisData.physical.numberOfStool,
+          physicalActivity: diagnosisData.physical.comment,
+        },
+        STEP_1: {
+          isCognitiveHelperChecked: diagnosisData.cognitive.assistCognitiveCare,
+          isCommunicationHelperChecked:
+            diagnosisData.cognitive.assistCommunication,
+          physicalActivity: diagnosisData.cognitive.comment,
+        },
+        STEP_2: {
+          isHealthManagementChecked: diagnosisData.healthCare.healthCare,
+          isNursingManagementChecked: diagnosisData.healthCare.nursingCare,
+          isEmergencyServiceChecked: diagnosisData.healthCare.emergencyService,
+          systolic: diagnosisData.healthCare.bloodPressure.systolic,
+          diastolic: diagnosisData.healthCare.bloodPressure.diastolic,
+          temperature: diagnosisData.healthCare.temperature.temperature,
+          healthManageSpecialNote: diagnosisData.healthCare.comment,
+        },
+        STEP_3: {
+          isTrainingChecked: diagnosisData.recoveryProgram.motionTraining,
+          isCognitiveActivityTrainingChecked:
+            diagnosisData.recoveryProgram.cognitiveProgram,
+          isCognitiveFunctionEnhancementTrainingChecked:
+            diagnosisData.recoveryProgram.cognitiveEnhancement,
+          isPhysicalTherapyChecked:
+            diagnosisData.recoveryProgram.physicalTherapy,
+          trainingSpecialNote: diagnosisData.recoveryProgram.comment,
+          programEntries: diagnosisData.recoveryProgram.programEntries,
+          signatureUrl: diagnosisData.signatureUrl,
+        },
+      } as FunnelState;
+    }
+
+    // localStorage에서도 확인 (atom 초기화 전 대비) - 데이터가 있고 physical이 존재하는 경우만
+    const stored = getStoredValue<DiagnosisFunnelData>(
+      "careSheet:diagnosisFunnel"
+    );
+    if (stored && stored.physical) {
+      return {
+        STEP_0: {
+          isWashHelperChecked: stored.physical.assistWashing,
+          isMoveHelperChecked: stored.physical.assistMovement,
+          isBathHelperChecked: stored.physical.assistBathing,
+          isBreakfastChecked: stored.physical.breakfast.provided,
+          breakfastType:
+            MEAL_TYPE_CODE_TO_LABEL[
+              stored.physical.breakfast.entry.mealType || ""
+            ] || stored.physical.breakfast.entry.mealType,
+          breakfastAmount:
+            MEAL_AMOUNT_CODE_TO_LABEL[
+              stored.physical.breakfast.entry.amount || ""
+            ] || stored.physical.breakfast.entry.amount,
+          isLunchChecked: stored.physical.lunch.provided,
+          lunchType:
+            MEAL_TYPE_CODE_TO_LABEL[
+              stored.physical.lunch.entry.mealType || ""
+            ] || stored.physical.lunch.entry.mealType,
+          lunchAmount:
+            MEAL_AMOUNT_CODE_TO_LABEL[
+              stored.physical.lunch.entry.amount || ""
+            ] || stored.physical.lunch.entry.amount,
+          isDinnerChecked: stored.physical.dinner.provided,
+          dinnerType:
+            MEAL_TYPE_CODE_TO_LABEL[
+              stored.physical.dinner.entry.mealType || ""
+            ] || stored.physical.dinner.entry.mealType,
+          dinnerAmount:
+            MEAL_AMOUNT_CODE_TO_LABEL[
+              stored.physical.dinner.entry.amount || ""
+            ] || stored.physical.dinner.entry.amount,
+          urineCount: stored.physical.numberOfUrine,
+          stoolCount: stored.physical.numberOfStool,
+          physicalActivity: stored.physical.comment,
+        },
+        STEP_1: {
+          isCognitiveHelperChecked: stored.cognitive.assistCognitiveCare,
+          isCommunicationHelperChecked: stored.cognitive.assistCommunication,
+          physicalActivity: stored.cognitive.comment,
+        },
+        STEP_2: {
+          isHealthManagementChecked: stored.healthCare.healthCare,
+          isNursingManagementChecked: stored.healthCare.nursingCare,
+          isEmergencyServiceChecked: stored.healthCare.emergencyService,
+          systolic: stored.healthCare.bloodPressure.systolic,
+          diastolic: stored.healthCare.bloodPressure.diastolic,
+          temperature: stored.healthCare.temperature.temperature,
+          healthManageSpecialNote: stored.healthCare.comment,
+        },
+        STEP_3: {
+          isTrainingChecked: stored.recoveryProgram.motionTraining,
+          isCognitiveActivityTrainingChecked:
+            stored.recoveryProgram.cognitiveProgram,
+          isCognitiveFunctionEnhancementTrainingChecked:
+            stored.recoveryProgram.cognitiveEnhancement,
+          isPhysicalTherapyChecked: stored.recoveryProgram.physicalTherapy,
+          trainingSpecialNote: stored.recoveryProgram.comment,
+          programEntries: stored.recoveryProgram.programEntries,
+          signatureUrl: stored.signatureUrl,
+        },
+      } as FunnelState;
+    }
+
+    return undefined;
   }, [diagnosisData]);
 
   return (

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/diagnosis-funnel/steps/Step5/Step5.tsx
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/diagnosis-funnel/steps/Step5/Step5.tsx
@@ -10,6 +10,9 @@ import { StepButtons } from "@/pages/care-sheet/components/StepButtons";
 import { useStep5 } from "./useStep5";
 import { useFunnel } from "@daycan/hooks";
 import { useUploadImageSingleMutation } from "@/services/image/useUploadImageMutation";
+import { convertFunnelStateToDiagnosisFunnelData } from "../../utils/parsingData";
+import { diagnosisFunnelDataAtom } from "../../atoms/diagnosisAtom";
+import { useSetAtom } from "jotai";
 
 export const Step5 = () => {
   const { toNext } = useFunnel();
@@ -28,6 +31,7 @@ export const Step5 = () => {
   } = useStep5();
   const { mutate } = useUploadImageSingleMutation();
   const { updateState, funnelState } = useFunnel();
+  const setDiagnosisData = useSetAtom(diagnosisFunnelDataAtom);
 
   const handleSignatureUpload = async () => {
     // PNG 데이터를 API로 전송하는 로직 예시
@@ -38,7 +42,11 @@ export const Step5 = () => {
           updateState({
             signatureUrl: result.objectKey,
           });
-          console.log(funnelState);
+
+          const diagnosisData =
+            convertFunnelStateToDiagnosisFunnelData(funnelState);
+
+          setDiagnosisData(diagnosisData);
         },
       });
     }

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/home-funnel/HomeFunnelStepContainer.tsx
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/home-funnel/HomeFunnelStepContainer.tsx
@@ -4,8 +4,8 @@ import { homeFunnelSteps } from "../../constants/steps";
 import { useSetAtom, useAtomValue } from "jotai";
 import { homeFunnelDataAtom } from "./atoms/homeAtom";
 import { convertFunnelStateToHomeFunnelData } from "./utils/parseData";
-import { useMemo } from "react";
 import { getStoredValue } from "../utils/storage";
+import { useMemo } from "react";
 import type { HomeFunnelData } from "./types/homeType";
 
 export const HomeFunnelStepContainer = () => {
@@ -57,7 +57,7 @@ export const HomeFunnelStepContainer = () => {
       funnelId="home-funnel"
       onComplete={handleComplete}
       initialState={initialState}
-      initialStep={initialState ? "STEP_1" : "STEP_0"}
+      initialStep={initialState ? "STEP_1" : undefined}
     >
       <FunnelStep name="STEP_0">
         <Step0 />

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/home-funnel/steps/Step0/Step0.tsx
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/home-funnel/steps/Step0/Step0.tsx
@@ -58,6 +58,7 @@ export const Step0 = () => {
 
     // FunnelState에 데이터 저장
     updateState({
+      writerId: staff.staffId,
       selectedStaff: staff,
       searchQuery: staff.name,
     });

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/home-funnel/steps/Step1/Step1.tsx
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/home-funnel/steps/Step1/Step1.tsx
@@ -20,6 +20,8 @@ import {
 import { useGetCareSheetListQuery } from "@/services/careSheet/useCareSheetQuery";
 import { CareSheetListItem } from "@/pages/care-sheet-today/components/CareSheetListItem";
 import { TODAY_DATE } from "@/utils/dateFormatter";
+import { useAtomValue } from "jotai";
+import { homeFunnelDataAtom } from "../../atoms/homeAtom";
 
 // localStorage 키 상수
 const RECENT_METHOD_KEY = "careSheet:recentMethod";
@@ -28,7 +30,7 @@ export const Step1 = () => {
   const navigate = useNavigate();
   const { toPrev, toNext, funnelState } = useFunnel();
   const [recentMethod, setRecentMethod] = useState<string | null>(null);
-
+  const homeFunnelData = useAtomValue(homeFunnelDataAtom);
   // 작성자 이름 가져오기
   const staffName = getStaffName(funnelState);
 
@@ -90,7 +92,13 @@ export const Step1 = () => {
             <div
               className={todayWritedCareSheetTitle}
               onClick={() => {
-                navigate("/care-sheet/new/today");
+                if (funnelState?.STEP_0?.writerId) {
+                  navigate(
+                    `/care-sheet/new/today/${funnelState?.STEP_0?.writerId}`
+                  );
+                } else {
+                  `/care-sheet/new/today/${homeFunnelData?.writerId}`;
+                }
               }}
             >
               <Body type="medium" weight={600} color={COLORS.gray[600]}>

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/home-funnel/utils/parseData.ts
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/home-funnel/utils/parseData.ts
@@ -27,9 +27,8 @@ export const convertFunnelStateToHomeFunnelData = (
   funnelState: FunnelState
 ): HomeFunnelData => {
   const step0Data = funnelState.STEP_0;
-  const selectedStaff: TStaff = step0Data?.selectedStaff;
 
   return {
-    writerId: selectedStaff?.staffId,
+    writerId: step0Data?.writerId,
   };
 };

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/info-funnel/InfoFunnelStepContainer.tsx
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/info-funnel/InfoFunnelStepContainer.tsx
@@ -38,35 +38,62 @@ export const InfoFunnelStepContainer = () => {
   useEffect(() => {
     const stored = getStoredValue("careSheet:homeFunnel");
     if (stored === null) {
-      navigate("/care-sheet/new", { replace: true });
+      navigate("/care-sheet/new");
     }
   }, [homeData, navigate]);
 
-  // photo-funnel로부터 채워진 info atom을 funnelState로 프리필
+  // photo-funnel로부터 채워진 info-funnel atom을 funnelState로 프리필
   const initialState: FunnelState | undefined = useMemo(() => {
-    const d: InfoFunnelData | null = infoData;
-    if (!d) return undefined;
+    // atom에서 데이터 확인 - 데이터가 있고 memberId가 존재하는 경우만
+    if (infoData && infoData.memberId) {
+      return {
+        STEP_0: {
+          memberId: infoData.memberId,
+          searchQuery: "",
+        },
+        STEP_1: {
+          date: infoData.date,
+          isToday: false,
+        },
+        STEP_2: {
+          startTime: infoData.startTime,
+        },
+        STEP_3: {
+          endTime: infoData.endTime,
+        },
+        STEP_4: {
+          isUsedCarService: Boolean(infoData.mobilityNumber),
+          carNumber: infoData.mobilityNumber || "",
+        },
+      } as FunnelState;
+    }
 
-    return {
-      STEP_0: {
-        memberId: d.memberId,
-        searchQuery: "",
-      },
-      STEP_1: {
-        date: new Date(d.date),
-        isToday: false,
-      },
-      STEP_2: {
-        startTime: d.startTime,
-      },
-      STEP_3: {
-        endTime: d.endTime,
-      },
-      STEP_4: {
-        isUsedCarService: Boolean(d.mobilityNumber),
-        carNumber: d.mobilityNumber || "",
-      },
-    } as FunnelState;
+    // localStorage에서도 확인 (atom 초기화 전 대비) - 데이터가 있고 memberId가 존재하는 경우만
+    const stored = getStoredValue<InfoFunnelData>("careSheet:infoFunnel");
+    if (stored && stored.memberId) {
+      return {
+        STEP_0: {
+          memberId: stored.memberId,
+          searchQuery: "",
+        },
+        STEP_1: {
+          date: stored.date,
+          isToday: false,
+        },
+        STEP_2: {
+          startTime: stored.startTime,
+        },
+        STEP_3: {
+          endTime: stored.endTime,
+        },
+        STEP_4: {
+          isUsedCarService: Boolean(stored.mobilityNumber),
+          carNumber: stored.mobilityNumber || "",
+        },
+      } as FunnelState;
+    }
+
+    return undefined;
   }, [infoData]);
 
   return (

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/info-funnel/utils/parsingData.ts
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/info-funnel/utils/parsingData.ts
@@ -29,7 +29,7 @@ export const convertFunnelStateToInfoFunnelData = (
   const step4Data = funnelState.STEP_4;
 
   return {
-    memberId: step0Data?.recipientId || step0Data?.selectedMember?.id,
+    memberId: step0Data?.memberId,
     date: step1Data?.date,
     startTime: step2Data?.startTime,
     endTime: step3Data?.endTime,

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/molecule/finalMolecule.ts
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/molecule/finalMolecule.ts
@@ -10,6 +10,8 @@ export const combinedCareSheetAtom = atom((get) => {
   const infoData = get(infoFunnelDataAtom);
   const diagnosisData = get(diagnosisFunnelDataAtom);
 
+  console.log("combinedCareSheetAtom", homeData, infoData, diagnosisData);
+
   return combineFunnelData(homeData, infoData, diagnosisData);
 });
 

--- a/daycan-front/apps/admin/src/pages/care-sheet/funnels/utils/atomUtil.ts
+++ b/daycan-front/apps/admin/src/pages/care-sheet/funnels/utils/atomUtil.ts
@@ -25,3 +25,101 @@ export const combineFunnelData = (
     signatureUrl: diagnosisData.signatureUrl,
   };
 };
+
+// 검증 결과 타입
+export interface ValidationResult {
+  isValid: boolean;
+  message: string;
+  missingFields?: string[];
+  invalidTypes?: string[];
+}
+
+// TCareSheetWriteRequest 타입 체크 함수
+export const validateCareSheetData = (data: any): ValidationResult => {
+  if (!data || typeof data !== "object") {
+    return {
+      isValid: false,
+      message: "데이터가 없거나 객체가 아닙니다.",
+    };
+  }
+
+  const missingFields: string[] = [];
+  const invalidTypes: string[] = [];
+
+  // 필수 필드 존재 여부 검증
+  const requiredFields = [
+    "writerId",
+    "memberId",
+    "date",
+    "startTime",
+    "endTime",
+    "mobilityNumber",
+    "physical",
+    "cognitive",
+    "healthCare",
+    "recoveryProgram",
+  ];
+
+  for (const field of requiredFields) {
+    if (!(field in data)) {
+      missingFields.push(field);
+    }
+  }
+
+  // 중첩 객체 검증
+  const nestedObjects = [
+    { field: "physical", name: "신체활동" },
+    { field: "cognitive", name: "인지활동" },
+    { field: "healthCare", name: "건강관리" },
+    { field: "recoveryProgram", name: "회복프로그램" },
+  ];
+
+  for (const { field, name } of nestedObjects) {
+    if (!data[field] || typeof data[field] !== "object") {
+      missingFields.push(`${field} (${name})`);
+    }
+  }
+
+  // 타입 검증
+  const typeChecks = [
+    { field: "writerId", name: "작성자ID", expectedType: "number" },
+    { field: "memberId", name: "회원ID", expectedType: "number" },
+    { field: "date", name: "날짜", expectedType: "string" },
+    { field: "startTime", name: "시작시간", expectedType: "string" },
+    { field: "endTime", name: "종료시간", expectedType: "string" },
+    { field: "mobilityNumber", name: "이동번호", expectedType: "string" },
+  ];
+
+  for (const { field, name, expectedType } of typeChecks) {
+    if (data[field] !== undefined && typeof data[field] !== expectedType) {
+      invalidTypes.push(
+        `${field} (${name}): ${typeof data[field]} → ${expectedType}`
+      );
+    }
+  }
+
+  // 검증 결과 생성
+  if (missingFields.length > 0 || invalidTypes.length > 0) {
+    let message = "케어시트 데이터 검증에 실패했습니다.\n";
+
+    if (missingFields.length > 0) {
+      message += `\n누락된 필드:\n${missingFields.map((field) => `• ${field}`).join("\n")}`;
+    }
+
+    if (invalidTypes.length > 0) {
+      message += `\n\n잘못된 타입:\n${invalidTypes.map((type) => `• ${type}`).join("\n")}`;
+    }
+
+    return {
+      isValid: false,
+      message,
+      missingFields,
+      invalidTypes,
+    };
+  }
+
+  return {
+    isValid: true,
+    message: "케어시트 데이터 검증이 완료되었습니다.",
+  };
+};

--- a/daycan-front/apps/admin/src/pages/care-sheet/utils/parser.ts
+++ b/daycan-front/apps/admin/src/pages/care-sheet/utils/parser.ts
@@ -2,7 +2,7 @@ import { COLORS } from "@daycan/ui";
 
 export const getStatusInfo = (status: string) => {
   switch (status) {
-    case "SHEET_PENDING":
+    case "PENDING":
       return {
         text: "작성 필요",
         icon: "warningFilled",

--- a/daycan-front/apps/admin/src/router/routes.tsx
+++ b/daycan-front/apps/admin/src/router/routes.tsx
@@ -131,7 +131,7 @@ export const routes: TRoutes[] = [
         element: <OCRPhotoPage />,
       },
       {
-        path: "today",
+        path: "today/:writerId",
         element: <TodayCareSheetPage />,
       },
     ],

--- a/daycan-front/apps/admin/src/services/image/useUploadImageMutation.ts
+++ b/daycan-front/apps/admin/src/services/image/useUploadImageMutation.ts
@@ -21,7 +21,7 @@ export const useUploadImageMutation = () => {
 export const useUploadImageSingleMutation = () => {
   return useMutation({
     mutationFn: async (file: File) => {
-      await uploadSingleImage(file);
+      return await uploadSingleImage(file);
     },
   });
 };


### PR DESCRIPTION
## 관련 이슈

- Resolves : #186 
 
## 작업 사항

### 작동 영상

https://github.com/user-attachments/assets/a5185259-832d-4849-86f5-b7fef3d502db

### 반영사항 

- 기존의 atomWithStorage를 사용함에도 불구하고, 새로고침시에 hydration이 발생해서 먼저 랜더링이 된 뒤에(atom 값 미반영) atom 값이 반영되었던 에러를 해결합니다. -> 새로고침시 해당 funnel 내 데이터 존재할 시에는 funnel 의 끝으로 감.

- atomWithStorage의 생명주기 뿐만 아니라, Prefill 상황을 고려하여, 기존의 기록지에 수정하거나/ 일부 데이터를 OCR 을 통해 주입하는 데이터가 존재했을 때, 필수 데이터를 검증하는 로직을 추가합니다. -> 데이터 존재시엔 각 funnel의 끝으로 가고, 데이터 검증을 최종적으로 시행 후에, API 요청을 보냄

