### PR TITLE
Feature/fe/#207 로그인 유지 기능 추가 && 로그인 시 바로 reissue 발생시 생기는 문제 해결

### DIFF
--- a/daycan-front/apps/admin/src/contexts/QueryProvider.tsx
+++ b/daycan-front/apps/admin/src/contexts/QueryProvider.tsx
@@ -23,7 +23,14 @@ import { reIssueToken } from "@/services/auth";
 export function QueryClientProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
   const handleAuthError = () => {
-    const refreshToken = localStorage.getItem("refreshToken");
+    let refreshToken = localStorage.getItem("refreshToken");
+    let inSessionStorage = false;
+
+    if (!refreshToken) {
+      refreshToken = sessionStorage.getItem("refreshToken");
+      inSessionStorage = true;
+    }
+
     if (!refreshToken) {
       navigate("/login");
     } else {
@@ -31,7 +38,15 @@ export function QueryClientProvider({ children }: { children: ReactNode }) {
         .then((data) => {
           if (!data) return;
           localStorage.setItem("accessToken", data.accessToken);
-          localStorage.setItem("refreshToken", data.refreshToken);
+
+          if (inSessionStorage) {
+            sessionStorage.setItem("refreshToken", data.refreshToken);
+            localStorage.removeItem("refreshToken");
+          } else {
+            localStorage.setItem("refreshToken", data.refreshToken);
+            sessionStorage.removeItem("refreshToken");
+          }
+
           window.location.reload();
         })
         .catch(() => {

--- a/daycan-front/apps/admin/src/pages/login/hooks/useAdminLoginHook.ts
+++ b/daycan-front/apps/admin/src/pages/login/hooks/useAdminLoginHook.ts
@@ -1,5 +1,8 @@
 import { useReducer } from "react";
-import { useAdminLoginMutation } from "@/services/auth/useAdminAuthMutation";
+import {
+  useAdminLoginMutation,
+  useAdminLoginWithoutCheckMutation,
+} from "@/services/auth/useAdminAuthMutation";
 
 // 상태 타입 정의
 interface AdminLoginState {
@@ -97,6 +100,7 @@ const adminLoginReducer = (
 export const useAdminLoginHook = () => {
   const [state, dispatch] = useReducer(adminLoginReducer, initialState);
   const login = useAdminLoginMutation();
+  const loginWithoutCheck = useAdminLoginWithoutCheckMutation();
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch({ type: "SET_EMAIL", payload: e.target.value });
   };
@@ -117,10 +121,17 @@ export const useAdminLoginHook = () => {
 
     dispatch({ type: "CLEAR_ERROR_MESSAGE" });
 
-    await login.mutateAsync({
-      username: state.email,
-      password: state.password,
-    });
+    if (state.isChecked) {
+      await login.mutateAsync({
+        username: state.email,
+        password: state.password,
+      });
+    } else {
+      await loginWithoutCheck.mutateAsync({
+        username: state.email,
+        password: state.password,
+      });
+    }
 
     // 로그인 성공 시 라우팅 모달 열기
     dispatch({ type: "SET_IS_ADMIN_LOGIN_ROUTE_MODAL_OPEN", payload: true });

--- a/daycan-front/apps/admin/src/services/auth/useAdminAuthMutation.ts
+++ b/daycan-front/apps/admin/src/services/auth/useAdminAuthMutation.ts
@@ -26,6 +26,7 @@ export const useAdminLoginMutation = () => {
       }
       localStorage.setItem("accessToken", data.accessToken);
       localStorage.setItem("refreshToken", data.refreshToken);
+      sessionStorage.removeItem("refreshToken");
       showToast({
         data: {
           message: "로그인 성공",
@@ -68,6 +69,41 @@ export const useReAuthMutation = () => {
       showToast({
         data: {
           message: "인증이 완료되었습니다.",
+          type: "success",
+          variant: "pc",
+        },
+      });
+    },
+  });
+};
+
+export const useAdminLoginWithoutCheckMutation = () => {
+  const { showToast } = useToast();
+  return useMutation({
+    mutationFn: ({
+      username,
+      password,
+    }: {
+      username: string;
+      password: string;
+    }) => login(username, password),
+    onSuccess: (data: TLoginResponse | null) => {
+      if (!data) {
+        showToast({
+          data: {
+            message: "로그인 실패",
+            type: "error",
+            variant: "pc",
+          },
+        });
+        return;
+      }
+      localStorage.setItem("accessToken", data.accessToken);
+      sessionStorage.setItem("refreshToken", data.refreshToken);
+      localStorage.removeItem("refreshToken");
+      showToast({
+        data: {
+          message: "로그인 성공",
           type: "success",
           variant: "pc",
         },

--- a/daycan-front/apps/admin/src/services/instance.ts
+++ b/daycan-front/apps/admin/src/services/instance.ts
@@ -7,10 +7,18 @@ export const publicInstance = axios.create({
 
 export const privateInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
-  headers: {
-    Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-  },
 });
 
+// 리프레시 토큰이 있을때만 accessToken 헤더에 추가
+privateInstance.interceptors.request.use((config) => {
+  const RefreshToken =
+    localStorage.getItem("refreshToken") ||
+    sessionStorage.getItem("refreshToken");
+  if (RefreshToken) {
+    const accessToken = localStorage.getItem("accessToken");
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
+});
 // applyDevLoggingInterceptor(publicInstance);
 // applyDevLoggingInterceptor(privateInstance);

--- a/daycan-front/apps/client/src/contexts/QueryProvider.tsx
+++ b/daycan-front/apps/client/src/contexts/QueryProvider.tsx
@@ -23,7 +23,13 @@ import { reIssueToken } from "@/services/auth";
 export function QueryClientProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
   const handleAuthError = () => {
-    const refreshToken = localStorage.getItem("refreshToken");
+    let refreshToken = localStorage.getItem("refreshToken");
+    let inSessionStorage = false;
+    if (!refreshToken) {
+      refreshToken = sessionStorage.getItem("refreshToken");
+      inSessionStorage = true;
+    }
+
     if (!refreshToken) {
       navigate("/login");
     } else {
@@ -31,7 +37,15 @@ export function QueryClientProvider({ children }: { children: ReactNode }) {
         .then((data) => {
           if (!data) return;
           localStorage.setItem("accessToken", data.accessToken);
-          localStorage.setItem("refreshToken", data.refreshToken);
+
+          if (inSessionStorage) {
+            sessionStorage.setItem("refreshToken", data.refreshToken);
+            localStorage.removeItem("refreshToken");
+          } else {
+            localStorage.setItem("refreshToken", data.refreshToken);
+            sessionStorage.removeItem("refreshToken");
+          }
+
           window.location.reload();
         })
         .catch(() => {

--- a/daycan-front/apps/client/src/pages/login/hooks/useLoginHook.ts
+++ b/daycan-front/apps/client/src/pages/login/hooks/useLoginHook.ts
@@ -1,5 +1,9 @@
 import { useReducer } from "react";
-import { useLoginMutation } from "@/services/auth/useAuthMutation";
+import {
+  useLoginMutation,
+  useLoginWithoutCheckMutation,
+} from "@/services/auth/useAuthMutation";
+import { useNavigate } from "react-router-dom";
 
 // 상태 타입 정의
 interface LoginState {
@@ -85,7 +89,8 @@ const loginReducer = (state: LoginState, action: LoginAction): LoginState => {
 export const useLoginHook = () => {
   const [state, dispatch] = useReducer(loginReducer, initialState);
   const loginMutation = useLoginMutation();
-
+  const loginWithoutCheckMutation = useLoginWithoutCheckMutation();
+  const navigate = useNavigate();
   const handleIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch({ type: "SET_ID", payload: e.target.value });
   };
@@ -109,13 +114,22 @@ export const useLoginHook = () => {
     dispatch({ type: "CLEAR_ERROR_MESSAGE" });
 
     // 로그인 API 호출
-    await loginMutation.mutateAsync({
-      username: state.id,
-      password: state.password,
-    });
+    if (state.isChecked) {
+      await loginMutation.mutateAsync({
+        username: state.id,
+        password: state.password,
+      });
+    } else {
+      await loginWithoutCheckMutation.mutateAsync({
+        username: state.id,
+        password: state.password,
+      });
+    }
 
     // 성공 시 폼 리셋
     resetForm();
+
+    navigate("/");
   };
 
   const setIsChecked = (value: boolean) => {

--- a/daycan-front/apps/client/src/services/auth/useAuthMutation.ts
+++ b/daycan-front/apps/client/src/services/auth/useAuthMutation.ts
@@ -2,11 +2,9 @@ import { useMutation } from "@tanstack/react-query";
 import { login, reIssueToken } from ".";
 import type { TLoginResponse } from "./types";
 import { useToast } from "@daycan/ui";
-import { useNavigate } from "react-router-dom";
 
 export const useLoginMutation = () => {
   const { showToast } = useToast();
-  const navigate = useNavigate();
   return useMutation({
     mutationFn: ({
       username,
@@ -16,11 +14,19 @@ export const useLoginMutation = () => {
       password: string;
     }) => login(username, password),
     onSuccess: (data: TLoginResponse | null) => {
-      if (!data) return;
+      if (!data) {
+        showToast({
+          data: {
+            message: "로그인 실패",
+            type: "error",
+            variant: "mobile",
+          },
+        });
+        return;
+      }
       localStorage.setItem("accessToken", data.accessToken);
       localStorage.setItem("refreshToken", data.refreshToken);
-      navigate("/");
-
+      sessionStorage.removeItem("refreshToken");
       showToast({
         data: {
           message: "로그인 성공",
@@ -40,6 +46,41 @@ export const useReIssueTokenMutation = () => {
       if (!data) return;
       localStorage.setItem("accessToken", data.accessToken);
       localStorage.setItem("refreshToken", data.refreshToken);
+    },
+  });
+};
+
+export const useLoginWithoutCheckMutation = () => {
+  const { showToast } = useToast();
+  return useMutation({
+    mutationFn: ({
+      username,
+      password,
+    }: {
+      username: string;
+      password: string;
+    }) => login(username, password),
+    onSuccess: (data: TLoginResponse | null) => {
+      if (!data) {
+        showToast({
+          data: {
+            message: "로그인 실패",
+            type: "error",
+            variant: "mobile",
+          },
+        });
+        return;
+      }
+      localStorage.setItem("accessToken", data.accessToken);
+      sessionStorage.setItem("refreshToken", data.refreshToken);
+      localStorage.removeItem("refreshToken");
+      showToast({
+        data: {
+          message: "로그인 성공",
+          type: "success",
+          variant: "mobile",
+        },
+      });
     },
   });
 };

--- a/daycan-front/apps/client/src/services/instance.ts
+++ b/daycan-front/apps/client/src/services/instance.ts
@@ -14,7 +14,17 @@ export const publicInstance = axios.create({
  */
 export const privateInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
-  headers: {
-    Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-  },
+});
+
+// 리프레시 토큰이 있을때만 accessToken 헤더에 추가
+// 권한 에러 방지
+privateInstance.interceptors.request.use((config) => {
+  const RefreshToken =
+    localStorage.getItem("refreshToken") ||
+    sessionStorage.getItem("refreshToken");
+  if (RefreshToken) {
+    const accessToken = localStorage.getItem("accessToken");
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
 });


### PR DESCRIPTION
## 관련 이슈

- Resolves : #207 
 
## 작업 사항

## 문제 발생

### 현재 발생하는 문제 동영상
https://github.com/user-attachments/assets/4731049d-3438-401e-b65e-667e220acc73
- 현재 발생하는 문제점은 원래라면 reissue가 발생했다면 refreshToken을 이용해 accessToken을 재발급 받으면서 메인(private한 공간들) 페이지에 접근이 가능해야합니다.
- 하지만 현재는 로그인과 동시에  reissue가 발생하면서 시작을 합니다. 그 후 accessToken을 지우면 다시 reissue가 발생하면서, accessToken을 받아오고 재접근이 가능해야 하는데 블랙리스트로 적용이 되어 token을 받아조지 못하고 바로 /login 로 강제 라우팅이 되어 버립니다.

<br>

### 문제 상황을 디버깅으로 파악

https://github.com/user-attachments/assets/2eeccff1-2407-4c07-881f-53fb7a551744
- 이번에는 디버깅 로그를 찍으면서 천천히 진행하였는데 발견한 사실은 두가지 문제가 있음을 파악했습니다.
- 첫번째 문제는 privateInstanse header에 Authorization: accessToken을 심는 순서의 문제였습니다.
-  {  로그인 성공 후 accessToken을 localStorage에 심음 ->  Authorization: accessToken을 적용 } 이 순서를 따라야 하는데 현재 적용되고 있는 로직은 {  Authorization: accessToken을 적용 ->  로그인 성공 후 accessToken을 localStorage에 심음 }이 적용되고 있었습니다.
- 따라서 로그인을 하고 accessToken을 LocalStorage에 심은 후에도 Authorization : Bearer 이후 accessToken자리에 아무 값도 없이 요청이 보내져서 reissue가 발생 했습니다.
- 두번째 문제는 속도에 따른 결과가 달라진다는 것입니다. 이 부분은 동기 비동기 문제인거 같은데 많은 생각을 했지만 저도 잘 모르겠습니다. 디버깅 툴을 키고 하면 처음에  reissue를 하더라도 accessToken을 다시 받아오기 때문에 결과적으로 잘 동작 했지만, 디버깅을 끄고 진행했다면 갑자기 블랙리스트에 걸리면서 accessToken을 못받아오고 그대로 /login 로 강제 라우팅이 되어 버립니다.

<br>

### 문제 코드 수정
<img width="599" height="314" alt="문제 코드 변경" src="https://github.com/user-attachments/assets/761fa980-cdf2-4fae-beea-72d36622e97b" />

- 최대한 원래 설계 흐름에 방해가 되지 않는 방식으로 코드를 수정해 보았습니다.privateInstance.interceptors.request.use을 적용해 요청을 보내기 refreshToken이 존재한다면 accessToken을 심을 수 있도록 수정해 보았습니다.
- refreshToken조건을 걸지 않고 accessToken으로 if문을 건다면 후에 아예 Authorization이 적용되지 않아 백엔드에서 오류가 발생해 '토큰이 없습니다'라는 에러를 잡게 되어 refreshToken으로 조건을 걸었습니다.

<br>

### 문제 해결 후 결과 
- 디버깅 무

https://github.com/user-attachments/assets/1b730cc6-8a45-42bd-87a2-58d362393cff

- 디버깅 유


https://github.com/user-attachments/assets/d5d0f668-be2d-4f30-bc1d-088a04043736


이젠 로그인과 동시에 reissue문제도 발생하지 않고, 블랙리스트 문제도 발생하지 않게 되었습니다.

<br>

## 로그인 유지 기능 추가


https://github.com/user-attachments/assets/6a68e436-72e4-4563-a156-cddea440745a

- 로그인 유지 기능을 추가하였습니다. 로그인 유지를 하기 위해 refreshToken을 localStorage에 넣어 브라우저가 닫히더라도 값을 가지고 있을 수 있도록 하였고, 로그인 유지 선택을 하지 않는다면 sessionStorage에 refreshToken을 집어 넣어 브라우저가 닫히면 값이 사라질 수 있도록 하였습니다.


## 참고 사항
- 모든 영상에서 제가 accessToken과 refreshToken을 자워가면서 테스트를 진행하였기에 개발자 탭이 계속 켜지고 꺼짐이 있습니다. 양해 부탁드립니다.
