### PR TITLE
hotfix: 서버 설정 변경 (장애 방지)

### DIFF
--- a/daycan-back/api/src/main/resources/application-develop.yml
+++ b/daycan-back/api/src/main/resources/application-develop.yml
@@ -1,3 +1,14 @@
+server:
+  shutdown: graceful
+  connection-timeout: 10s
+  tomcat:
+    threads:
+      max: 64
+      min-spare: 16
+    accept-count: 100
+    max-connections: 2048
+    keep-alive-timeout: 10s
+
 spring:
   mvc:
     throw-exception-if-no-handler-found: true
@@ -19,9 +30,9 @@ jwt:
   custom:
     secretKey: ${JWT_SECRET_KEY}
   access-token:
-    expire-length: 604800000 #1시간
+    expire-length: 3600000
   refresh-token:
-    expire-length: 604800000 #일주일
+    expire-length: 604800000
 
 app:
   aws:


### PR DESCRIPTION
오늘 발생한 장애를 대비해 gpt와 논의해 서버 설정을 적용했습니다.

- connection-timeout: 10s (초기 요청 읽기 타임아웃(모바일 고려해 10s))
- 스레드 스택(기본 1MB 가정)이 100MB+만 써도, 힙/메타/버퍼 합쳐 여유가 급감, 톰캣 최대 쓰레드 : 64
- keep-alive 10s max-connections 2048로 시작하면 메모리 압박 완화
